### PR TITLE
refactor: Add interpolation callbacks and helpers.

### DIFF
--- a/src/pydrex/interpolations.py
+++ b/src/pydrex/interpolations.py
@@ -155,7 +155,8 @@ def create_interpolators(interpolator, coords, data, triangles=None, **kwargs):
     Optional kwargs will be passed to the interpolation constructor.
 
     Returns a tuple of interpolator callbacks, one for each data vector component.
-    For scalar data, the tuple contains only one interpolator.
+    For "scalar" data, i.e. arrays of shape (N, 1) where N is the number of nodes,
+    the tuple contains only one interpolator.
 
     The `triangles` arg is required only for "CubicTriInterpolator".
     See the documentation of that constructor for details.
@@ -204,7 +205,7 @@ def create_interpolators(interpolator, coords, data, triangles=None, **kwargs):
 
 def _validate_choice(interpolator, dimension, data):
     """Validate interpolator choice and return constructor class if valid."""
-    is_scalar = len(data.shape) == 1 or (len(data.shape) == 2 and 1 in data.shape)
+    is_scalar = len(data.shape) == 2 and 1 in data.shape
 
     interpolator_choices = {"NearestNDInterpolator": "scipy.interpolate"}
     if not is_scalar and dimension == 2:

--- a/src/pydrex/interpolations.py
+++ b/src/pydrex/interpolations.py
@@ -1,0 +1,281 @@
+"""PyDRex: Interpolation callbacks and helpers."""
+# NOTE: Module contains delayed imports (search for 'Delayed import' comments).
+import importlib
+import itertools as it
+
+import numpy as np
+
+import pydrex.exceptions as _err
+import pydrex.vtk_helpers as _vtk
+import pydrex.deformation_mechanism as _defmech
+
+
+def default_interpolators(config, coords, vtk_output, mpl_interp=None):
+    """Create a dictionary of default interpolator callbacks for PyDRex input.
+
+    Args:
+        `config` (dict) — PyDRex configuration parameters
+        `coords` (2D or 3D NumPy array) — coordinates of the interpolation mesh
+        `vtk_output` (vtk{Un,S}tructuredGrid) — the VTK input grid
+
+    Optionaly pass a string to `mpl_interp` to use
+    `matplotlib.tri.CubicTriInterpolator` with the chosen smoothing algorithm.
+    Only valid for 2D data with pre-existing triangulations.
+
+    See also `pydrex.interpolators.create_interpolators`.
+
+    """
+    if config["mesh"]["dimension"] != coords.shape[1]:
+        raise _err.MeshError(
+            "dimensions of coordinate mesh and interpolation mesh must match."
+            + f" You've supplied a {coords.shape[1]}D coordinate mesh,"
+            + f" and a {config['mesh']['dimension']}D interpolation mesh."
+        )
+
+    is_2d = config["mesh"]["dimension"] == 2
+    # Get a `vtkPointData` pointer to the actual data.
+    data = vtk_output.GetPointData()
+
+    try:
+        deformation_mechanism = _vtk.read_tuple_array(
+            data, "DeformationMechanism", skip_z=is_2d
+        )
+    except LookupError:
+        n_nodes = np.product(config["mesh"]["gridnodes"])
+        deformation_mechanism = np.empty(n_nodes).fill(_defmech.Regime.dislocation)
+
+    velocity = _vtk.read_tuple_array(data, "Velocity", skip_z=is_2d)
+    velocity_gradient = _vtk.read_tuple_array(data, "VelocityGradient", skip_z=is_2d)
+    if is_2d:
+        fields = (
+            "velocity_x",
+            "velocity_z",
+            "grad_velocity_xx",
+            "grad_velocity_zx",
+            "grad_velocity_xz",
+            "grad_velocity_zz",
+            "deformation_mechanism",
+        )
+
+        if mpl_interp is not None:
+            # Extract triangle vertex IDs to allow using existing triangulation.
+            tri_IDs = []
+            for i in range(vtk_output.GetNumberOfCells()):
+                assert vtk_output.GetCell(i).GetNumberOfPoints() == 3
+                IDs = vtk_output.GetCell(i).GetPointIds()
+                tri_IDs.append([IDs.GetId(j) for j in range(IDs.GetNumberOfIds())])
+
+            interpolators = dict(
+                zip(
+                    fields,
+                    it.chain(
+                        create_interpolators(
+                            "CubicTriInterpolator",
+                            coords,
+                            velocity,
+                            triangles=tri_IDs,
+                            kind=mpl_interp,
+                        ),
+                        create_interpolators(
+                            "CubicTriInterpolator",
+                            coords,
+                            velocity_gradient,
+                            triangles=tri_IDs,
+                            kind=mpl_interp,
+                        ),
+                        create_interpolators(
+                            "NearestNDInterpolator",
+                            coords,
+                            deformation_mechanism,
+                        ),
+                    ),
+                )
+            )
+
+        else:  # 2D, mpl_interp is None
+            interpolators = dict(
+                zip(
+                    fields,
+                    it.chain(
+                        *map(
+                            create_interpolators,
+                            (
+                                "CloughTocher2DInterpolator",
+                                "CloughTocher2DInterpolator",
+                                "NearestNDInterpolator",
+                            ),
+                            [coords] * 3,
+                            (velocity, velocity_gradient, deformation_mechanism),
+                        )
+                    ),
+                )
+            )
+
+    else:  # 3D
+        interpolators = dict(
+            zip(
+                [
+                    "velocity_x",
+                    "velocity_y",
+                    "velocity_z",
+                    "grad_velocity_xx",
+                    "grad_velocity_yx",
+                    "grad_velocity_zx",
+                    "grad_velocity_xy",
+                    "grad_velocity_yy",
+                    "grad_velocity_zy",
+                    "grad_velocity_xz",
+                    "grad_velocity_yz",
+                    "grad_velocity_zz",
+                    "deformation_mechanism",
+                ],
+                it.chain(
+                    *map(
+                        create_interpolators,
+                        ["NearestNDInterpolator"] * 3,
+                        [coords] * 3,
+                        (velocity, velocity_gradient, deformation_mechanism),
+                    )
+                ),
+            )
+        )
+
+    return interpolators
+
+
+def create_interpolators(interpolator, coords, data, triangles=None, **kwargs):
+    """Create interpolator callbacks for data arrays.
+
+    Args:
+        `intepolator` (string) — name of interpolator class to use, see below
+        `coords` (2D or 3D NumPy array) — coordinates of the finite element mesh
+        `data` (NumPy array) — data used to create the interpolators
+        `triangles` (optional) — 2D triangle vertex indices, see below
+
+    Optional kwargs will be passed to the interpolation constructor.
+
+    Returns a tuple of interpolator callbacks, one for each data vector component.
+    For scalar data, the tuple contains only one interpolator.
+
+    The `triangles` arg is required only for "CubicTriInterpolator".
+    See the documentation of that constructor for details.
+
+    Supported interpolator choices (dim = `coords.shape[1]`):
+
+    |                                 |   scalar data   |   vector data   |
+    |       interpolator              |    and dim ==   |    and dim ==   |
+    |                                 |   2    |   3    |   2    |   3    |
+    |---------------------------------------------------------------------|
+    | "CloughTocher2DInterpolator" [1]|        |        |   x    |        |
+    | "CubicTriInterpolator" [2]      |        |        |   x    |        |
+    | "NearestNDInterpolator" [3]     |   x    |   x    |        |   x    |
+
+    [1]: scipy.interpolate.CloughTocher2DInterpolator
+    [2]: matplotlib.tri.CubicTriInterpolator
+    [3]: scipy.interpolate.NearestNDInterpolator
+
+    """
+    dimension = coords.shape[1]
+    assert dimension in (2, 3)
+    # NOTE: Delayed import.
+    interpclass = _validate_choice(interpolator, dimension, data)
+
+    if dimension == 2:
+        if interpolator == "CloughTocher2DInterpolator":
+            from scipy.spatial import Delaunay  # NOTE: Delayed import.
+
+            tri = Delaunay(coords)
+        elif interpolator == "CubicTriInterpolator":
+            if triangles is None:
+                raise ValueError(
+                    "the `triangles` arg is required for {interpolator} interpolation."
+                )
+            from matplotlib.tri import Triangulation  # NOTE: Delayed import.
+
+            tri = Triangulation(coords[:, 0], coords[:, 1], triangles=triangles)
+
+        if interpolator == "NearestNDInterpolator":
+            return [interpclass(coords, data, **kwargs)]
+
+        return [interpclass(tri, data[:, i], **kwargs) for i in range(data.shape[1])]
+
+    return [interpclass(coords, data[:, i], **kwargs) for i in range(data.shape[1])]
+
+
+def _validate_choice(interpolator, dimension, data):
+    """Validate interpolator choice and return constructor class if valid."""
+    is_scalar = len(data.shape) == 1 or (len(data.shape) == 2 and 1 in data.shape)
+
+    interpolator_choices = {"NearestNDInterpolator": "scipy.interpolate"}
+    if not is_scalar and dimension == 2:
+        interpolator_choices = {
+            "CloughTocher2DInterpolator": "scipy.interpolate",
+            "CubicTriInterpolator": "matplotlib.tri",
+        }
+
+    if interpolator not in interpolator_choices:
+        raise ValueError(
+            "`interpolator` must be a valid interpolator choice (check documentation)."
+            + f" You've supplied `{interpolator}` with {dimension}D coordinates"
+            + f" and {'scalar' if is_scalar else 'vector'} data."
+        )
+    return getattr(
+        importlib.import_module(interpolator_choices[interpolator]),
+        interpolator
+    )
+
+
+def get_velocity(point, interpolators):
+    """Interpolates the velocity at a given point."""
+    if len(point) == 2:
+        return np.array(
+            [
+                interpolators["velocity_x"](*point),
+                -interpolators["velocity_z"](*point),
+            ]
+        )
+
+    return np.array(
+        [
+            interpolators["velocity_x"](*point),
+            interpolators["velocity_y"](*point),
+            -interpolators["velocity_z"](*point),
+        ]
+    )
+
+
+def get_velocity_gradient(point, interpolators):
+    """Return the interpolated velocity gradient tensor at a given point."""
+    if len(point) == 2:
+        return np.array(
+            [
+                [
+                    interpolators["grad_velocity_xx"](*point),
+                    -interpolators["grad_velocity_xz"](*point),
+                ],
+                [
+                    -interpolators["grad_velocity_zx"](*point),
+                    interpolators["grad_velocity_zz"](*point),
+                ],
+            ]
+        )
+
+    return np.array(
+        [
+            [
+                interpolators["grad_velocity_xx"](*point),
+                interpolators["grad_velocity_xy"](*point),
+                -interpolators["grad_velocity_xz"](*point),
+            ],
+            [
+                interpolators["grad_velocity_yx"](*point),
+                interpolators["grad_velocity_yy"](*point),
+                -interpolators["grad_velocity_yz"](*point),
+            ],
+            [
+                -interpolators["grad_velocity_zx"](*point),
+                -interpolators["grad_velocity_zy"](*point),
+                interpolators["grad_velocity_zz"](*point),
+            ],
+        ]
+    )

--- a/src/pydrex/vtk_helpers.py
+++ b/src/pydrex/vtk_helpers.py
@@ -70,11 +70,10 @@ def read_tuple_array(points, fieldname, skip_z=False):
     return a
 
 
-def read_coord_array(vtkgrid, components, skip_z=False, depth_conversion=True):
+def read_coord_array(vtkgrid, skip_z=False, depth_conversion=True):
     """Read coordinates from `vtkgrid` into a numpy array.
 
-    Extract coordinates with an integer number of `components` from
-    a vtk{Uns,S}tructuredGrid object.
+    Create a numpy array with coordinates extracted from a vtk{Uns,S}tructuredGrid object.
 
     If `skip_z` is True, the third dimension is assumed to be full of zeros.
     This is the standard behaviour for 2D fluidity model output.
@@ -91,6 +90,7 @@ def read_coord_array(vtkgrid, components, skip_z=False, depth_conversion=True):
         coords = _skip_column_every(a, 3)
     else:
         coords = a
-    # Convert Z coordinates from height to depth values.
-    coords[:, -1] = np.amax(coords[:, -1]) - coords[:, -1]
+    if depth_conversion:
+        # Convert Z coordinates from height to depth values.
+        coords[:, -1] = np.amax(coords[:, -1]) - coords[:, -1]
     return coords


### PR DESCRIPTION
Adds some functions to organise interpolator callbacks.
This was previously handled in `main`. At the moment the option to use
matplotlib interpolation is handled in command line args.
It could make sense to move that into the configuration file later.