### PR TITLE
feat: Add draft of shearbox example

### DIFF
--- a/examples/shearbox/run.sh
+++ b/examples/shearbox/run.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+set -eu
+readonly SCRIPTNAME="${0##*/}"
+readonly MESH_SMALL='shearbox_1m.msh'
+#readonly MESH_LARGE='shearbox_100km.msh'
+readonly OPTS_SMALL='shearbox_single_particle.flml'
+#readonly OPTS_LARGE='shearbox_500_particles.flml'
+
+warn() { >&2 printf '%s\n' "$SCRIPTNAME: $1" ; }
+
+is_command() { # Check if command exists, for flow control (no stdout messages)
+    if 1>/dev/null 2>&1 command -v "$1"; then
+        return 0
+    else
+        warn "command '$1' not found"; return 1
+    fi
+}
+
+has_python_module() {
+    is_command python3 || return 1
+    1>/dev/null 2>&1 python3 -m "$1" \
+        || { warn "failed to import '$1' from python3" ; return 1 ; }
+}
+
+# Check environment for necessary executables and modules.
+is_command pydrex || exit 1
+is_command fluidity || exit 1
+has_python_module "fluidity.state_types" || exit 1
+has_python_module "gmsh" || exit 1
+is_command mpirun || exit 1
+is_command flredecomp || exit 1
+
+# Create output directory, fail if the last simulation wasn't cleaned up.
+mkdir out
+
+# Copy or generate mesh files.
+if [ -f "src/$MESH_SMALL" ] && [ -f "src/$MESH_LARGE" ] ; then
+    cp "src/$MESH_SMALL" out
+#    cp "src/$MESH_LARGE" out
+else
+    >out/gmsh.log python3 ./src/shearbox_gmsh.py -o out
+fi
+
+# Copy model options files.
+cp "src/$OPTS_SMALL" out
+#cp "src/$OPTS_LARGE" out
+
+# Copy auxiliary model files.
+cp src/shearbox_pydrex.py out
+cp src/shearbox_single.ini out
+#cp src/shearbox_500.ini out
+
+# Run the simulations.
+( cd out
+    fluidity -v2 -l "$OPTS_SMALL"
+    #fluidity -v2 -l "$OPTS_LARGE"
+    pydrex --ncpus 8 --config shearbox_single.ini "${OPTS_SMALL%.flml}_1.vtu"
+    #pydrex --ncpus 8 --config shearbox_500.ini "${OPTS_LARGE%.flml}_1.vtu"
+    #>>pydrex.log mpirun -np 8 pydrex --charm "${OPTS_SMALL%.flml}_1.vtu"
+    #>>pydrex.log mpirun -np 8 pydrex --charm "${OPTS_LARGE%.flml}_1.vtu"
+)

--- a/examples/shearbox/src/shearbox_500.ini
+++ b/examples/shearbox/src/shearbox_500.ini
@@ -1,0 +1,20 @@
+# Example simulation setup for PyDRex:
+# <https://github.com/Patol75/PyDRex>
+
+[Geometry]
+# Relative paths will be resolved from the directory containing this file.
+meshfile = shearbox_pydrex.py
+
+[Output]
+simulation_name = shearbox_500
+olivine = volume_distribution, orientations
+enstatite = volume_distribution, orientations
+
+[Parameters]
+olivine_fraction = 0.7
+stress_exponent = 3.5
+gbm_mobility = 125
+gbs_threshold = 0.3
+nucleation_efficiency = 5
+olivine_fabric = A
+number_of_grains = 2000

--- a/examples/shearbox/src/shearbox_500_particles.flml
+++ b/examples/shearbox/src/shearbox_500_particles.flml
@@ -1,0 +1,117 @@
+<?xml version='1.0' encoding='utf-8'?>
+<fluidity_options>
+  <simulation_name>
+    <string_value lines="1">shearbox_500_particles</string_value>
+  </simulation_name>
+  <problem_type>
+    <string_value lines="1">stokes</string_value>
+  </problem_type>
+  <geometry>
+    <dimension>
+      <integer_value rank="0">3</integer_value>
+    </dimension>
+    <mesh name="CoordinateMesh">
+      <from_file file_name="shearbox_100km">
+        <format name="gmsh"/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_file>
+    </mesh>
+    <mesh name="VelocityMesh">
+      <from_mesh>
+        <mesh name="CoordinateMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <quadrature>
+      <degree>
+        <integer_value rank="0">5</integer_value>
+      </degree>
+    </quadrature>
+  </geometry>
+  <io>
+    <dump_format>
+      <string_value>vtk</string_value>
+    </dump_format>
+    <dump_period>
+      <constant>
+        <real_value rank="0">100</real_value>
+      </constant>
+    </dump_period>
+    <output_mesh name="CoordinateMesh"/>
+    <stat/>
+  </io>
+  <timestepping>
+    <current_time>
+      <real_value rank="0">0</real_value>
+    </current_time>
+    <timestep>
+      <real_value rank="0">1</real_value>
+    </timestep>
+    <finish_time>
+      <real_value rank="0">1</real_value>
+    </finish_time>
+  </timestepping>
+  <material_phase name="Fluid">
+    <vector_field rank="1" name="Velocity">
+      <prescribed>
+        <mesh name="VelocityMesh"/>
+        <value name="WholeMesh">
+          <python>
+            <string_value type="code" language="python" lines="20">def val(X, t):
+    return (X[2] / 1e4, 0, 0)</string_value>
+          </python>
+        </value>
+        <output/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+        <particles>
+          <exclude_from_particles/>
+        </particles>
+      </prescribed>
+    </vector_field>
+    <scalar_field rank="0" name="DeformationMechanism">
+      <prescribed>
+        <mesh name="VelocityMesh"/>
+        <value name="WholeMesh">
+          <constant>
+            <real_value rank="0">1</real_value>
+          </constant>
+        </value>
+        <output/>
+        <stat/>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+        <particles>
+          <exclude_from_particles/>
+        </particles>
+      </prescribed>
+    </scalar_field>
+    <tensor_field rank="2" name="VelocityGradient">
+      <diagnostic>
+        <algorithm name="grad_vector" material_phase_support="single " source_field_name="Velocity" source_field_type="vector"/>
+        <mesh name="CoordinateMesh"/>
+        <output/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+        <particles>
+          <exclude_from_particles/>
+        </particles>
+      </diagnostic>
+    </tensor_field>
+  </material_phase>
+</fluidity_options>

--- a/examples/shearbox/src/shearbox_gmsh.py
+++ b/examples/shearbox/src/shearbox_gmsh.py
@@ -1,0 +1,117 @@
+"""Generate shearbox cube meshes using the gmsh API
+
+See also the gmsh API tutorial:
+<https://gitlab.onelab.info/gmsh/gmsh/-/tree/master/demos/api>.
+
+The API is defined in this file:
+<https://gitlab.onelab.info/gmsh/gmsh/-/blob/master/api/gmsh.py>.
+
+"""
+import argparse
+import pathlib
+import os
+
+import gmsh as gm  # type: ignore
+
+
+def _get_args() -> argparse.Namespace:
+    description, epilog = __doc__.split(os.linesep + os.linesep, 1)
+    parser = argparse.ArgumentParser(description=description, epilog=epilog)
+    parser.add_argument(
+        "-o",
+        "--outdir",
+        help="path to the output directory, which must already exist",
+        required=True,
+    )
+    return parser.parse_args()
+
+
+def write_shearbox(outfile, edgelength, resolution):
+    """Write a shearbox cube mesh to `outfile`.
+
+    Specify the total length of one edge of the cube with `edgelength`.
+    Specify the initial resolution of the mesh with `resolution`.
+    It is used to set the initial edge length for the elements.
+
+    """
+    outpath = pathlib.Path(outfile)
+    print(f"Creating mesh '{outfile}'...")
+    gm.initialize()
+    gm.model.add(outpath.stem)
+
+    gm.option.setNumber("Mesh.MshFileVersion", 2.2)
+    #gm.option.setNumber("Mesh.PartitionOldStyleMsh2", 1)
+    #gm.option.setNumber("Mesh.PartitionCreateGhostCells", 1)
+
+    # Set up coordinates for the front face (positive x-axis forward, right-handed axes).
+    # Points are specified as (x, y, z, target_edge_length_for_neighbouring_elements)
+    front_vertices = [
+        (edgelength / 2, -edgelength / 2, -edgelength / 2, resolution),
+        (edgelength / 2, edgelength / 2, -edgelength / 2, resolution),
+        (edgelength / 2, edgelength / 2, edgelength / 2, resolution),
+        (edgelength / 2, -edgelength / 2, edgelength / 2, resolution),
+    ]
+    # Create points from coodinates.
+    front_vertex_tags = [gm.model.geo.addPoint(*point) for point in front_vertices]
+    # Create lines joining pairs of points.
+    front_line_tags = [
+        gm.model.geo.addLine(point, front_vertex_tags[(i + 1) % len(front_vertex_tags)])
+        for i, point in enumerate(front_vertex_tags)
+    ]
+    # Create front face.
+    front_face_tag = gm.model.geo.addPlaneSurface(
+        [gm.model.geo.addCurveLoop(front_line_tags)]
+    )
+    # Create remaining tags using extrusion.
+    # The returned sequence contains tuples of the form (dimension, tag) for:
+    # - the last extruded component entity at index 0 (read it again),
+    # - the extruded entity itself at index 1, and
+    # - the remaining components at successive indices.
+    # The ordering of the remaining components is not documented... ¯\_(ツ)_/¯
+    # Seems to be anticlockwise from the bottom side for a cube, i.e. bottom, right, top, left
+    # See also <https://gmsh.info/doc/texinfo/gmsh.html#Extrusions>
+    (
+        (_, back_face_tag),
+        (_, volume_tag),
+        (_, bot_face_tag),
+        (_, right_face_tag),
+        (_, top_face_tag),
+        (_, left_face_tag),
+    ) = gm.model.geo.extrude(
+        [(2, front_face_tag)], -edgelength, 0, 0, [round(edgelength / resolution)]
+    )
+
+    gm.model.geo.synchronize()
+
+    # First arg to addPhysicalGroup() is the component dimension: 0D, 1D, 2D or 3D
+    #front_phys_tag = gm.model.addPhysicalGroup(2, [front_face_tag])
+    #gm.model.setPhysicalName(2, front_phys_tag, "Front")
+    #back_phys_tag = gm.model.addPhysicalGroup(2, [back_face_tag])
+    #gm.model.setPhysicalName(2, back_phys_tag, "Back")
+    #bot_phys_tag = gm.model.addPhysicalGroup(2, [bot_face_tag])
+    #gm.model.setPhysicalName(2, bot_phys_tag, "Bottom")
+    #right_phys_tag = gm.model.addPhysicalGroup(2, [right_face_tag])
+    #gm.model.setPhysicalName(2, right_phys_tag, "Right")
+    #top_phys_tag = gm.model.addPhysicalGroup(2, [top_face_tag])
+    #gm.model.setPhysicalName(2, top_phys_tag, "Top")
+    #left_phys_tag = gm.model.addPhysicalGroup(2, [left_face_tag])
+    #gm.model.setPhysicalName(2, left_phys_tag, "Left")
+
+    gm.model.mesh.generate(3)  # Generate 3D mesh
+    # Using pathlib allows relative paths and it's a nice API.
+    gm.write(f"{outpath.resolve()}")
+
+    #print(f"Front surface tag: {front_phys_tag}")
+    #print(f"Back surface tag: {back_phys_tag}")
+    #print(f"Bottom surface tag: {bot_phys_tag}")
+    #print(f"Right surface tag: {right_phys_tag}")
+    #print(f"Top surface tag: {top_phys_tag}")
+    #print(f"Left surface tag: {left_phys_tag}")
+
+    gm.finalize()
+
+
+if __name__ == "__main__":
+    ARGS = _get_args()
+    write_shearbox(f"{ARGS.outdir}/shearbox_1m.msh", 1, 0.1)
+    write_shearbox(f"{ARGS.outdir}/shearbox_100km.msh", 1e5, 1e4)

--- a/examples/shearbox/src/shearbox_pydrex.py
+++ b/examples/shearbox/src/shearbox_pydrex.py
@@ -1,0 +1,8 @@
+import numpy as np
+gridcoords = np.array(
+    [
+        np.linspace(-0.5, 0.5, 11),  # X
+        np.linspace(-0.5, 0.5, 11),  # Y
+        np.linspace(-0.5, 0.5, 11),  # Z
+    ]
+)

--- a/examples/shearbox/src/shearbox_single.ini
+++ b/examples/shearbox/src/shearbox_single.ini
@@ -1,0 +1,20 @@
+# Example simulation setup for PyDRex:
+# <https://github.com/Patol75/PyDRex>
+
+[Geometry]
+# Relative paths will be resolved from the directory containing this file.
+meshfile = shearbox_pydrex.py
+
+[Output]
+simulation_name = shearbox_single
+olivine = volume_distribution, orientations
+enstatite = volume_distribution, orientations
+
+[Parameters]
+olivine_fraction = 0.7
+stress_exponent = 3.5
+gbm_mobility = 125
+gbs_threshold = 0.3
+nucleation_efficiency = 5
+olivine_fabric = A
+number_of_grains = 2000

--- a/examples/shearbox/src/shearbox_single_particle.flml
+++ b/examples/shearbox/src/shearbox_single_particle.flml
@@ -1,0 +1,117 @@
+<?xml version='1.0' encoding='utf-8'?>
+<fluidity_options>
+  <simulation_name>
+    <string_value lines="1">shearbox_single_particle</string_value>
+  </simulation_name>
+  <problem_type>
+    <string_value lines="1">stokes</string_value>
+  </problem_type>
+  <geometry>
+    <dimension>
+      <integer_value rank="0">3</integer_value>
+    </dimension>
+    <mesh name="CoordinateMesh">
+      <from_file file_name="shearbox_1m">
+        <format name="gmsh"/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_file>
+    </mesh>
+    <mesh name="VelocityMesh">
+      <from_mesh>
+        <mesh name="CoordinateMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <quadrature>
+      <degree>
+        <integer_value rank="0">5</integer_value>
+      </degree>
+    </quadrature>
+  </geometry>
+  <io>
+    <dump_format>
+      <string_value>vtk</string_value>
+    </dump_format>
+    <dump_period>
+      <constant>
+        <real_value rank="0">100</real_value>
+      </constant>
+    </dump_period>
+    <output_mesh name="CoordinateMesh"/>
+    <stat/>
+  </io>
+  <timestepping>
+    <current_time>
+      <real_value rank="0">0</real_value>
+    </current_time>
+    <timestep>
+      <real_value rank="0">1</real_value>
+    </timestep>
+    <finish_time>
+      <real_value rank="0">1</real_value>
+    </finish_time>
+  </timestepping>
+  <material_phase name="Fluid">
+    <vector_field rank="1" name="Velocity">
+      <prescribed>
+        <mesh name="VelocityMesh"/>
+        <value name="WholeMesh">
+          <python>
+            <string_value type="code" language="python" lines="20">def val(X, t):
+    return (X[2] / 1e5, 0, 0)</string_value>
+          </python>
+        </value>
+        <output/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+        <particles>
+          <exclude_from_particles/>
+        </particles>
+      </prescribed>
+    </vector_field>
+    <scalar_field rank="0" name="DeformationMechanism">
+      <prescribed>
+        <mesh name="VelocityMesh"/>
+        <value name="WholeMesh">
+          <constant>
+            <real_value rank="0">1</real_value>
+          </constant>
+        </value>
+        <output/>
+        <stat/>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+        <particles>
+          <exclude_from_particles/>
+        </particles>
+      </prescribed>
+    </scalar_field>
+    <tensor_field rank="2" name="VelocityGradient">
+      <diagnostic>
+        <algorithm name="grad_vector" material_phase_support="single " source_field_name="Velocity" source_field_type="vector"/>
+        <mesh name="CoordinateMesh"/>
+        <output/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+        <particles>
+          <exclude_from_particles/>
+        </particles>
+      </diagnostic>
+    </tensor_field>
+  </material_phase>
+</fluidity_options>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+# Boilerplate for modern (PEP517, PEP518) build systems.
+# The setup.cfg metadata may eventually migrate over here, see:
+# https://github.com/pypa/setuptools/issues/1688
+# https://www.python.org/dev/peps/pep-0621/
+# https://snarky.ca/what-the-heck-is-pyproject-toml/
+[build-system]
+requires = ["setuptools >= 42", "wheel", "setuptools_scm[toml]>=3.4"]
+build-backend = "setuptools.build_meta"
+
+# Automatically use the version number from vcs (e.g. git) tags,
+# <https://github.com/pypa/setuptools_scm>.
+[tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,49 @@
+# Packaging configuration and metadata.
+# <https://packaging.python.org/en/latest/tutorials/packaging-projects/>
+# <https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html>
+# <https://docs.python.org/3/distutils/configfile.html>
+# Note: optional deps are possible using [extras] but it's too painful
+# Note: test deps might be possible using tests_require but I couldn't work it out
+[metadata]
+name = pydrex
+description = Dynamic CPO calculations for olivine-enstatite polycrystal aggregates
+long_description = file: README.md
+keywords = CPO, LPO, olivine, deformation, anisotropy, crystallography
+license = GNU General Public License v3.0 only
+classifiers =
+    License :: OSI Approved :: GNU General Public License v3 (GPLv3)
+    Programming Language :: Python :: 3
+    Intended Audience :: Developers
+    Intended Audience :: Science/Research
+
+[options]
+# YES, IT NEEDS THE SECOND '=', <https://github.com/pypa/setuptools/issues/1259>.
+package_dir =
+    = src
+# Find all the *.py files in options.packages.find["where"] (recursive).
+packages = find:
+
+# ===== Runtime dependencies =====
+# It would be nice to require a specific (minimum) Python version,
+# but python_version is broken, see e.g. <https://github.com/pypa/setuptools/issues/1633>.
+# - `numpy` 1.8 for <https://numpy.org/doc/stable/reference/generated/numpy.linalg.eigvalsh.html>
+# - `numba` 0.5 for <https://numba.pydata.org/numba-doc/latest/release-notes.html#version-0-50-0-jun-10-2020>
+# - `scipy` 1.2 for <https://github.com/scipy/scipy/pull/9176>
+# - `mplstereonet` for pole figures
+# - `vtk` for the data readers
+install_requires =
+    numpy >= 1.8
+    numba >= 0.5
+    scipy >= 1.2
+    matplotlib
+    mplstereonet
+    vtk
+
+# ===== Entry points =====
+[options.entry_points]
+console_scripts =
+    pydrex = pydrex.run:main
+
+# Required for src/ setup.
+[options.packages.find]
+where = src

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+"""Setuptools shim for pre-PEP571 build methods."""
+import setuptools  # type: ignore
+
+# DO NOT EDIT, use setup.cfg instead.
+if __name__ == "__main__":
+    setuptools.setup()


### PR DESCRIPTION
Currently CPO is calculated for the whole domain,
probably needs a way to mask nodes that we are not interested in?