### PR TITLE
style: Change naming convention for orientation derivatives

### DIFF
--- a/src/pydrex/minerals.py
+++ b/src/pydrex/minerals.py
@@ -147,7 +147,7 @@ class Mineral:
             assert False  # Should never happen.
 
         # ========== RK step  1 ==========
-        rotation_rates, fractions_diff = _core.derivatives(
+        orientations_diff, fractions_diff = _core.derivatives(
             phase=self.phase,
             fabric=self.fabric,
             n_grains=self.n_grains,
@@ -161,7 +161,7 @@ class Mineral:
             gbm_mobility=gbm_mobility,
             volume_fraction=volume_fraction,
         )
-        orientations_1 = rotation_rates * dt * strain_rate_max
+        orientations_1 = orientations_diff * dt * strain_rate_max
         orientations_iter = self.orientations + 0.5 * orientations_1
         orientations_iter.clip(-1, 1)
         fractions_1 = fractions_diff * dt * strain_rate_max
@@ -170,7 +170,7 @@ class Mineral:
         fractions_iter /= fractions_iter.sum()
 
         # ========== RK step  2 ==========
-        rotation_rates, fractions_diff = _core.derivatives(
+        orientations_diff, fractions_diff = _core.derivatives(
             phase=self.phase,
             fabric=self.fabric,
             n_grains=self.n_grains,
@@ -184,7 +184,7 @@ class Mineral:
             gbm_mobility=gbm_mobility,
             volume_fraction=volume_fraction,
         )
-        orientations_2 = rotation_rates * dt * strain_rate_max
+        orientations_2 = orientations_diff * dt * strain_rate_max
         orientations_iter = self.orientations + 0.5 * orientations_2
         orientations_iter.clip(-1, 1)
         fractions_2 = fractions_diff * dt * strain_rate_max
@@ -193,7 +193,7 @@ class Mineral:
         fractions_iter /= fractions_iter.sum()
 
         # ========== RK step 3 ==========
-        rotation_rates, fractions_diff = _core.derivatives(
+        orientations_diff, fractions_diff = _core.derivatives(
             phase=self.phase,
             fabric=self.fabric,
             n_grains=self.n_grains,
@@ -207,7 +207,7 @@ class Mineral:
             gbm_mobility=gbm_mobility,
             volume_fraction=volume_fraction,
         )
-        orientations_3 = rotation_rates * dt * strain_rate_max
+        orientations_3 = orientations_diff * dt * strain_rate_max
         orientations_iter = self.orientations + orientations_3
         orientations_iter.clip(-1, 1)
         fractions_3 = fractions_diff * dt * strain_rate_max
@@ -216,7 +216,7 @@ class Mineral:
         fractions_iter /= fractions_iter.sum()
 
         # ========== RK step 4 ==========
-        rotation_rates, fractions_diff = _core.derivatives(
+        orientations_diff, fractions_diff = _core.derivatives(
             phase=self.phase,
             fabric=self.fabric,
             n_grains=self.n_grains,
@@ -230,7 +230,7 @@ class Mineral:
             gbm_mobility=gbm_mobility,
             volume_fraction=volume_fraction,
         )
-        orientations_4 = rotation_rates * dt * strain_rate_max
+        orientations_4 = orientations_diff * dt * strain_rate_max
         self.orientations = (
             self.orientations
             + (

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -37,7 +37,7 @@ class TestDerivatives:
         # Grain initialised with rotation around Z (active rotation convention).
         θ = np.deg2rad(10)
         initial_orientations = Rotation.from_rotvec([[0, 0, θ]])
-        rotation_rate, fractions_diff = _core.derivatives(
+        orientations_diff, fractions_diff = _core.derivatives(
             phase=_minerals.MineralPhase.olivine,
             fabric=_minerals.OlivineFabric.A,
             n_grains=1,
@@ -54,14 +54,14 @@ class TestDerivatives:
         cosθ = np.cos(θ)
         cos2θ = np.cos(2*θ)
         sinθ = np.sin(θ)
-        print("calculated rotation rate:\n", rotation_rate)
-        target_rotation_rate = np.array([
+        print("calculated rotation rate:\n", orientations_diff)
+        target_orientations_diff = np.array([
             [sinθ * (1 + cos2θ), cosθ * (1 + cos2θ), 0],
             [cosθ * (- 1 - cos2θ), sinθ * (1 + cos2θ), 0],
             [0, 0, 0],
         ])
-        print("target rotation rate:\n", target_rotation_rate)
-        assert np.allclose(rotation_rate, target_rotation_rate)
+        print("target rotation rate:\n", target_orientations_diff)
+        assert np.allclose(orientations_diff, target_orientations_diff)
 
     def test_simple_shear_init10Z_anti(self):
         # Single grain of olivine A-type, simple shear with:
@@ -73,7 +73,7 @@ class TestDerivatives:
         # Grain initialised with rotation around Z (active rotation convention).
         θ = np.deg2rad(-10)
         initial_orientations = Rotation.from_rotvec([[0, 0, θ]])
-        rotation_rate, fractions_diff = _core.derivatives(
+        orientations_diff, fractions_diff = _core.derivatives(
             phase=_minerals.MineralPhase.olivine,
             fabric=_minerals.OlivineFabric.A,
             n_grains=1,
@@ -90,14 +90,14 @@ class TestDerivatives:
         cosθ = np.cos(θ)
         cos2θ = np.cos(2*θ)
         sinθ = np.sin(θ)
-        print("calculated rotation rate:\n", rotation_rate)
-        target_rotation_rate = np.array([
+        print("calculated rotation rate:\n", orientations_diff)
+        target_orientations_diff = np.array([
             [sinθ * (1 + cos2θ), cosθ * (1 + cos2θ), 0],
             [cosθ * (- 1 - cos2θ), sinθ * (1 + cos2θ), 0],
             [0, 0, 0],
         ])
-        print("target rotation rate:\n", target_rotation_rate)
-        assert np.allclose(rotation_rate, target_rotation_rate)
+        print("target rotation rate:\n", target_orientations_diff)
+        assert np.allclose(orientations_diff, target_orientations_diff)
 
     def test_simple_shear_init45Z(self):
         # Single grain of olivine A-type, simple shear with:
@@ -109,7 +109,7 @@ class TestDerivatives:
         # Grain initialised with rotation around Z (active rotation convention).
         θ = np.deg2rad(45)
         initial_orientations = Rotation.from_rotvec([[0, 0, θ]])
-        rotation_rate, fractions_diff = _core.derivatives(
+        orientations_diff, fractions_diff = _core.derivatives(
             phase=_minerals.MineralPhase.olivine,
             fabric=_minerals.OlivineFabric.A,
             n_grains=1,
@@ -126,14 +126,14 @@ class TestDerivatives:
         cosθ = np.cos(θ)
         cos2θ = np.cos(2*θ)
         sinθ = np.sin(θ)
-        print("calculated rotation rate:\n", rotation_rate)
-        target_rotation_rate = np.array([
+        print("calculated rotation rate:\n", orientations_diff)
+        target_orientations_diff = np.array([
             [sinθ * (1 + cos2θ), cosθ * (1 + cos2θ), 0],
             [cosθ * (- 1 - cos2θ), sinθ * (1 + cos2θ), 0],
             [0, 0, 0],
         ])
-        print("target rotation rate:\n", target_rotation_rate)
-        assert np.allclose(rotation_rate, target_rotation_rate)
+        print("target rotation rate:\n", target_orientations_diff)
+        assert np.allclose(orientations_diff, target_orientations_diff)
 
     def test_simple_shear_init90Z(self):
         # Single grain of olivine A-type, simple shear with:
@@ -145,7 +145,7 @@ class TestDerivatives:
         # Grain initialised with rotation around Z (active rotation convention).
         θ = np.deg2rad(90)
         initial_orientations = Rotation.from_rotvec([[0, 0, θ]])
-        rotation_rate, fractions_diff = _core.derivatives(
+        orientations_diff, fractions_diff = _core.derivatives(
             phase=_minerals.MineralPhase.olivine,
             fabric=_minerals.OlivineFabric.A,
             n_grains=1,
@@ -162,14 +162,14 @@ class TestDerivatives:
         cosθ = np.cos(θ)
         cos2θ = np.cos(2*θ)
         sinθ = np.sin(θ)
-        print("calculated rotation rate:\n", rotation_rate)
-        target_rotation_rate = np.array([
+        print("calculated rotation rate:\n", orientations_diff)
+        target_orientations_diff = np.array([
             [sinθ * (1 + cos2θ), cosθ * (1 + cos2θ), 0],
             [cosθ * (- 1 - cos2θ), sinθ * (1 + cos2θ), 0],
             [0, 0, 0],
         ])
-        print("target rotation rate:\n", target_rotation_rate)
-        assert np.allclose(rotation_rate, target_rotation_rate)
+        print("target rotation rate:\n", target_orientations_diff)
+        assert np.allclose(orientations_diff, target_orientations_diff)
 
     def test_simple_shear_init10Y(self):
         # Single grain of olivine A-type, simple shear with:
@@ -181,7 +181,7 @@ class TestDerivatives:
         # Grain initialised with rotation around Y (active rotation convention).
         θ = np.deg2rad(10)
         initial_orientations = Rotation.from_rotvec([[0, θ, 0]])
-        rotation_rate, fractions_diff = _core.derivatives(
+        orientations_diff, fractions_diff = _core.derivatives(
             phase=_minerals.MineralPhase.olivine,
             fabric=_minerals.OlivineFabric.A,
             n_grains=1,
@@ -198,14 +198,14 @@ class TestDerivatives:
         cosθ = np.cos(θ)
         cos2θ = np.cos(2*θ)
         sinθ = np.sin(θ)
-        print("calculated rotation rate:\n", rotation_rate)
-        target_rotation_rate = np.array([
+        print("calculated rotation rate:\n", orientations_diff)
+        target_orientations_diff = np.array([
             [sinθ * (1 - cos2θ), 0, cosθ * (cos2θ - 1)],
             [0, 0, 0],
             [cosθ * (1 - cos2θ), 0, sinθ * (1 - cos2θ)],
         ])
-        print("target rotation rate:\n", target_rotation_rate)
-        assert np.allclose(rotation_rate, target_rotation_rate)
+        print("target rotation rate:\n", target_orientations_diff)
+        assert np.allclose(orientations_diff, target_orientations_diff)
 
     def test_simple_shear_init10Y_anti(self):
         # Single grain of olivine A-type, simple shear with:
@@ -217,7 +217,7 @@ class TestDerivatives:
         # Grain initialised with rotation around Y (active rotation convention).
         θ = np.deg2rad(-10)
         initial_orientations = Rotation.from_rotvec([[0, θ, 0]])
-        rotation_rate, fractions_diff = _core.derivatives(
+        orientations_diff, fractions_diff = _core.derivatives(
             phase=_minerals.MineralPhase.olivine,
             fabric=_minerals.OlivineFabric.A,
             n_grains=1,
@@ -234,14 +234,14 @@ class TestDerivatives:
         cosθ = np.cos(θ)
         cos2θ = np.cos(2*θ)
         sinθ = np.sin(θ)
-        print("calculated rotation rate:\n", rotation_rate)
-        target_rotation_rate = np.array([
+        print("calculated rotation rate:\n", orientations_diff)
+        target_orientations_diff = np.array([
             [sinθ * (1 - cos2θ), 0, cosθ * (cos2θ - 1)],
             [0, 0, 0],
             [cosθ * (1 - cos2θ), 0, sinθ * (1 - cos2θ)],
         ])
-        print("target rotation rate:\n", target_rotation_rate)
-        assert np.allclose(rotation_rate, target_rotation_rate)
+        print("target rotation rate:\n", target_orientations_diff)
+        assert np.allclose(orientations_diff, target_orientations_diff)
 
     def test_simple_shear_init45Y(self):
         # Single grain of olivine A-type, simple shear with:
@@ -253,7 +253,7 @@ class TestDerivatives:
         # Grain initialised with rotation around Y (active rotation convention).
         θ = np.deg2rad(45)
         initial_orientations = Rotation.from_rotvec([[0, θ, 0]])
-        rotation_rate, fractions_diff = _core.derivatives(
+        orientations_diff, fractions_diff = _core.derivatives(
             phase=_minerals.MineralPhase.olivine,
             fabric=_minerals.OlivineFabric.A,
             n_grains=1,
@@ -270,14 +270,14 @@ class TestDerivatives:
         cosθ = np.cos(θ)
         cos2θ = np.cos(2*θ)
         sinθ = np.sin(θ)
-        print("calculated rotation rate:\n", rotation_rate)
-        target_rotation_rate = np.array([
+        print("calculated rotation rate:\n", orientations_diff)
+        target_orientations_diff = np.array([
             [sinθ * (1 - cos2θ), 0, cosθ * (cos2θ - 1)],
             [0, 0, 0],
             [cosθ * (1 - cos2θ), 0, sinθ * (1 - cos2θ)],
         ])
-        print("target rotation rate:\n", target_rotation_rate)
-        assert np.allclose(rotation_rate, target_rotation_rate)
+        print("target rotation rate:\n", target_orientations_diff)
+        assert np.allclose(orientations_diff, target_orientations_diff)
 
     def test_simple_shear_init90Y(self):
         # Single grain of olivine A-type, simple shear with:
@@ -289,7 +289,7 @@ class TestDerivatives:
         # Grain initialised with rotation around Y (active rotation convention).
         θ = np.deg2rad(90)
         initial_orientations = Rotation.from_rotvec([[0, θ, 0]])
-        rotation_rate, fractions_diff = _core.derivatives(
+        orientations_diff, fractions_diff = _core.derivatives(
             phase=_minerals.MineralPhase.olivine,
             fabric=_minerals.OlivineFabric.A,
             n_grains=1,
@@ -306,11 +306,11 @@ class TestDerivatives:
         cosθ = np.cos(θ)
         cos2θ = np.cos(2*θ)
         sinθ = np.sin(θ)
-        print("calculated rotation rate:\n", rotation_rate)
-        target_rotation_rate = np.array([
+        print("calculated rotation rate:\n", orientations_diff)
+        target_orientations_diff = np.array([
             [sinθ * (1 - cos2θ), 0, cosθ * (cos2θ - 1)],
             [0, 0, 0],
             [cosθ * (1 - cos2θ), 0, sinθ * (1 - cos2θ)],
         ])
-        print("target rotation rate:\n", target_rotation_rate)
-        assert np.allclose(rotation_rate, target_rotation_rate)
+        print("target rotation rate:\n", target_orientations_diff)
+        assert np.allclose(orientations_diff, target_orientations_diff)


### PR DESCRIPTION
In all of the literature, "rotation rate" is not the derivative da/dt,
but actually the ω tensor, where a = k exp(- ∫ω dt).
In Fraters 2021 these are distinct tensors,
whereas at the moment we just calculate da/dt in one go.
It may be necessary to split this up for some advection methods.