### PR TITLE
fix: Fix grain size derivatie calculation

### DIFF
--- a/src/pydrex/core.py
+++ b/src/pydrex/core.py
@@ -279,7 +279,7 @@ def derivatives(
     mean_energy = np.sum(fractions * strain_energies)
     # Strain energy residual.
     strain_residuals = mean_energy - strain_energies
-    fractions_diff = volume_fraction * gbm_mobility * strain_residuals
+    fractions_diff = volume_fraction * gbm_mobility * fractions * strain_residuals
     return orientations_diff, fractions_diff
 
 


### PR DESCRIPTION
Should be multiplied by the previous grain size arrray,
see eq. 12 in Kaminski 2004 and eq. 10 & 11 in Fraters 2021.

(This was correct in PyDRex.py, I didn't copy it across correctly).