### PR TITLE
Add more grain tests

### DIFF
--- a/src/pydrex/minerals.py
+++ b/src/pydrex/minerals.py
@@ -156,7 +156,7 @@ class Mineral:
 
         def rhs(t, y):
             finite_strain_ell, orientations, fractions = extract_vars(y)
-            rotation_rates, fractions_diff = _core.derivatives(
+            orientations_diff, fractions_diff = _core.derivatives(
                 phase=self.phase,
                 fabric=self.fabric,
                 n_grains=self.n_grains,
@@ -172,7 +172,7 @@ class Mineral:
             )
             return np.hstack((
                 np.dot(velocity_gradient, finite_strain_ell).flatten(),
-                rotation_rates.flatten() * strain_rate_max,
+                orientations_diff.flatten() * strain_rate_max,
                 fractions_diff * strain_rate_max
             ))
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -12,7 +12,7 @@ import pydrex.deformation_mechanism as _defmech
 
 
 class TestDerivatives:
-    """Single-grain analytical rotation rate tests."""
+    """Single-grain analytical re-orientation rate tests."""
 
     # Kaminski used passive rotations (see Kaminski 2001 eq. 1) and ZXZ convention.
     # Scipy gives us active rotations by default,
@@ -27,7 +27,7 @@ class TestDerivatives:
     # where ci = cos(angle of i'th elementary rotation), si = sin(...),
     # which is the same as the passive version but transposed.
 
-    def test_simple_shear_init10Z(self):
+    def test_simple_shear_initP10Z(self):
         # Single grain of olivine A-type, simple shear with:
         #     0 0 0  .   0 1 0      0 -1 0
         # L = 2 0 0  ε = 1 0 0  Ω = 1  0 0
@@ -54,16 +54,16 @@ class TestDerivatives:
         cosθ = np.cos(θ)
         cos2θ = np.cos(2*θ)
         sinθ = np.sin(θ)
-        print("calculated rotation rate:\n", orientations_diff)
+        print("calculated re-orientation rate:\n", orientations_diff)
         target_orientations_diff = np.array([
             [sinθ * (1 + cos2θ), cosθ * (1 + cos2θ), 0],
             [cosθ * (- 1 - cos2θ), sinθ * (1 + cos2θ), 0],
             [0, 0, 0],
         ])
-        print("target rotation rate:\n", target_orientations_diff)
+        print("target re-orientation rate:\n", target_orientations_diff)
         assert np.allclose(orientations_diff, target_orientations_diff)
 
-    def test_simple_shear_init10Z_anti(self):
+    def test_simple_shear_initN10Z(self):
         # Single grain of olivine A-type, simple shear with:
         #     0 0 0  .   0 1 0      0 -1 0
         # L = 2 0 0  ε = 1 0 0  Ω = 1  0 0
@@ -90,16 +90,16 @@ class TestDerivatives:
         cosθ = np.cos(θ)
         cos2θ = np.cos(2*θ)
         sinθ = np.sin(θ)
-        print("calculated rotation rate:\n", orientations_diff)
+        print("calculated re-orientation rate:\n", orientations_diff)
         target_orientations_diff = np.array([
             [sinθ * (1 + cos2θ), cosθ * (1 + cos2θ), 0],
             [cosθ * (- 1 - cos2θ), sinθ * (1 + cos2θ), 0],
             [0, 0, 0],
         ])
-        print("target rotation rate:\n", target_orientations_diff)
+        print("target re-orientation rate:\n", target_orientations_diff)
         assert np.allclose(orientations_diff, target_orientations_diff)
 
-    def test_simple_shear_init45Z(self):
+    def test_simple_shear_initP45Z(self):
         # Single grain of olivine A-type, simple shear with:
         #     0 0 0  .   0 1 0      0 -1 0
         # L = 2 0 0  ε = 1 0 0  Ω = 1  0 0
@@ -126,16 +126,16 @@ class TestDerivatives:
         cosθ = np.cos(θ)
         cos2θ = np.cos(2*θ)
         sinθ = np.sin(θ)
-        print("calculated rotation rate:\n", orientations_diff)
+        print("calculated re-orientation rate:\n", orientations_diff)
         target_orientations_diff = np.array([
             [sinθ * (1 + cos2θ), cosθ * (1 + cos2θ), 0],
             [cosθ * (- 1 - cos2θ), sinθ * (1 + cos2θ), 0],
             [0, 0, 0],
         ])
-        print("target rotation rate:\n", target_orientations_diff)
+        print("target re-orientation rate:\n", target_orientations_diff)
         assert np.allclose(orientations_diff, target_orientations_diff)
 
-    def test_simple_shear_init90Z(self):
+    def test_simple_shear_initP90Z(self):
         # Single grain of olivine A-type, simple shear with:
         #     0 0 0  .   0 1 0      0 -1 0
         # L = 2 0 0  ε = 1 0 0  Ω = 1  0 0
@@ -162,16 +162,16 @@ class TestDerivatives:
         cosθ = np.cos(θ)
         cos2θ = np.cos(2*θ)
         sinθ = np.sin(θ)
-        print("calculated rotation rate:\n", orientations_diff)
+        print("calculated re-orientation rate:\n", orientations_diff)
         target_orientations_diff = np.array([
             [sinθ * (1 + cos2θ), cosθ * (1 + cos2θ), 0],
             [cosθ * (- 1 - cos2θ), sinθ * (1 + cos2θ), 0],
             [0, 0, 0],
         ])
-        print("target rotation rate:\n", target_orientations_diff)
+        print("target re-orientation rate:\n", target_orientations_diff)
         assert np.allclose(orientations_diff, target_orientations_diff)
 
-    def test_simple_shear_init10Y(self):
+    def test_simple_shear_initP10Y(self):
         # Single grain of olivine A-type, simple shear with:
         #     0 0 2  .   0 0 1       0 0 1
         # L = 0 0 0  ε = 0 0 0  Ω =  0 0 0
@@ -198,16 +198,16 @@ class TestDerivatives:
         cosθ = np.cos(θ)
         cos2θ = np.cos(2*θ)
         sinθ = np.sin(θ)
-        print("calculated rotation rate:\n", orientations_diff)
+        print("calculated re-orientation rate:\n", orientations_diff)
         target_orientations_diff = np.array([
             [sinθ * (1 - cos2θ), 0, cosθ * (cos2θ - 1)],
             [0, 0, 0],
             [cosθ * (1 - cos2θ), 0, sinθ * (1 - cos2θ)],
         ])
-        print("target rotation rate:\n", target_orientations_diff)
+        print("target re-orientation rate:\n", target_orientations_diff)
         assert np.allclose(orientations_diff, target_orientations_diff)
 
-    def test_simple_shear_init10Y_anti(self):
+    def test_simple_shear_initN10Y(self):
         # Single grain of olivine A-type, simple shear with:
         #     0 0 2  .   0 0 1       0 0 1
         # L = 0 0 0  ε = 0 0 0  Ω =  0 0 0
@@ -234,16 +234,16 @@ class TestDerivatives:
         cosθ = np.cos(θ)
         cos2θ = np.cos(2*θ)
         sinθ = np.sin(θ)
-        print("calculated rotation rate:\n", orientations_diff)
+        print("calculated re-orientation rate:\n", orientations_diff)
         target_orientations_diff = np.array([
             [sinθ * (1 - cos2θ), 0, cosθ * (cos2θ - 1)],
             [0, 0, 0],
             [cosθ * (1 - cos2θ), 0, sinθ * (1 - cos2θ)],
         ])
-        print("target rotation rate:\n", target_orientations_diff)
+        print("target re-orientation rate:\n", target_orientations_diff)
         assert np.allclose(orientations_diff, target_orientations_diff)
 
-    def test_simple_shear_init45Y(self):
+    def test_simple_shear_initP45Y(self):
         # Single grain of olivine A-type, simple shear with:
         #     0 0 2  .   0 0 1       0 0 1
         # L = 0 0 0  ε = 0 0 0  Ω =  0 0 0
@@ -270,16 +270,16 @@ class TestDerivatives:
         cosθ = np.cos(θ)
         cos2θ = np.cos(2*θ)
         sinθ = np.sin(θ)
-        print("calculated rotation rate:\n", orientations_diff)
+        print("calculated re-orientation rate:\n", orientations_diff)
         target_orientations_diff = np.array([
             [sinθ * (1 - cos2θ), 0, cosθ * (cos2θ - 1)],
             [0, 0, 0],
             [cosθ * (1 - cos2θ), 0, sinθ * (1 - cos2θ)],
         ])
-        print("target rotation rate:\n", target_orientations_diff)
+        print("target re-orientation rate:\n", target_orientations_diff)
         assert np.allclose(orientations_diff, target_orientations_diff)
 
-    def test_simple_shear_init90Y(self):
+    def test_simple_shear_initP90Y(self):
         # Single grain of olivine A-type, simple shear with:
         #     0 0 2  .   0 0 1       0 0 1
         # L = 0 0 0  ε = 0 0 0  Ω =  0 0 0
@@ -306,11 +306,11 @@ class TestDerivatives:
         cosθ = np.cos(θ)
         cos2θ = np.cos(2*θ)
         sinθ = np.sin(θ)
-        print("calculated rotation rate:\n", orientations_diff)
+        print("calculated re-orientation rate:\n", orientations_diff)
         target_orientations_diff = np.array([
             [sinθ * (1 - cos2θ), 0, cosθ * (cos2θ - 1)],
             [0, 0, 0],
             [cosθ * (1 - cos2θ), 0, sinθ * (1 - cos2θ)],
         ])
-        print("target rotation rate:\n", target_orientations_diff)
+        print("target re-orientation rate:\n", target_orientations_diff)
         assert np.allclose(orientations_diff, target_orientations_diff)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -28,7 +28,7 @@ class TestSimpleShearSingleGrains:
     # where ci = cos(angle of i'th elementary rotation), si = sin(...),
     # which is the same as the passive version but transposed.
 
-    def test_simple_shear_initP10Z(self):
+    def test_initP10Z(self):
         # Single grain of olivine A-type, simple shear with:
         #     0 0 0  .   0 1 0      0 -1 0
         # L = 2 0 0  ε = 1 0 0  Ω = 1  0 0
@@ -66,7 +66,7 @@ class TestSimpleShearSingleGrains:
         print("calculated grain volume change:\n", fractions_diff)
         assert np.isclose(np.sum(fractions_diff), 0.0)
 
-    def test_simple_shear_initN10Z(self):
+    def test_initN10Z(self):
         # Single grain of olivine A-type, simple shear with:
         #     0 0 0  .   0 1 0      0 -1 0
         # L = 2 0 0  ε = 1 0 0  Ω = 1  0 0
@@ -104,7 +104,7 @@ class TestSimpleShearSingleGrains:
         print("calculated grain volume changes:\n", fractions_diff)
         assert np.isclose(np.sum(fractions_diff), 0.0)
 
-    def test_simple_shear_initP45Z(self):
+    def test_initP45Z(self):
         # Single grain of olivine A-type, simple shear with:
         #     0 0 0  .   0 1 0      0 -1 0
         # L = 2 0 0  ε = 1 0 0  Ω = 1  0 0
@@ -142,7 +142,7 @@ class TestSimpleShearSingleGrains:
         print("calculated grain volume changes:\n", fractions_diff)
         assert np.isclose(np.sum(fractions_diff), 0.0)
 
-    def test_simple_shear_initP90Z(self):
+    def test_initP90Z(self):
         # Single grain of olivine A-type, simple shear with:
         #     0 0 0  .   0 1 0      0 -1 0
         # L = 2 0 0  ε = 1 0 0  Ω = 1  0 0
@@ -180,7 +180,7 @@ class TestSimpleShearSingleGrains:
         print("calculated grain volume changes:\n", fractions_diff)
         assert np.isclose(np.sum(fractions_diff), 0.0)
 
-    def test_simple_shear_initP10Y(self):
+    def test_initP10Y(self):
         # Single grain of olivine A-type, simple shear with:
         #     0 0 2  .   0 0 1       0 0 1
         # L = 0 0 0  ε = 0 0 0  Ω =  0 0 0
@@ -218,7 +218,7 @@ class TestSimpleShearSingleGrains:
         print("calculated grain volume changes:\n", fractions_diff)
         assert np.isclose(np.sum(fractions_diff), 0.0)
 
-    def test_simple_shear_initN10Y(self):
+    def test_initN10Y(self):
         # Single grain of olivine A-type, simple shear with:
         #     0 0 2  .   0 0 1       0 0 1
         # L = 0 0 0  ε = 0 0 0  Ω =  0 0 0
@@ -256,7 +256,7 @@ class TestSimpleShearSingleGrains:
         print("calculated grain volume changes:\n", fractions_diff)
         assert np.isclose(np.sum(fractions_diff), 0.0)
 
-    def test_simple_shear_initP45Y(self):
+    def test_initP45Y(self):
         # Single grain of olivine A-type, simple shear with:
         #     0 0 2  .   0 0 1       0 0 1
         # L = 0 0 0  ε = 0 0 0  Ω =  0 0 0
@@ -294,7 +294,7 @@ class TestSimpleShearSingleGrains:
         print("calculated grain volume changes:\n", fractions_diff)
         assert np.isclose(np.sum(fractions_diff), 0.0)
 
-    def test_simple_shear_initP90Y(self):
+    def test_initP90Y(self):
         # Single grain of olivine A-type, simple shear with:
         #     0 0 2  .   0 0 1       0 0 1
         # L = 0 0 0  ε = 0 0 0  Ω =  0 0 0
@@ -332,7 +332,7 @@ class TestSimpleShearSingleGrains:
         print("calculated grain volume changes:\n", fractions_diff)
         assert np.isclose(np.sum(fractions_diff), 0.0)
 
-    def test_simple_shear_random(self):
+    def test_random(self):
         # Single grain of olivine A-type with random initial orientation:
         #     0 0 0  .   0 1 0      0 -1 0
         # L = 2 0 0  ε = 1 0 0  Ω = 1  0 0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -62,6 +62,8 @@ class TestDerivatives:
         ])
         print("target re-orientation rate:\n", target_orientations_diff)
         assert np.allclose(orientations_diff, target_orientations_diff)
+        print("calculated grain volume change:\n", fractions_diff)
+        assert np.isclose(np.sum(fractions_diff), 0.0)
 
     def test_simple_shear_initN10Z(self):
         # Single grain of olivine A-type, simple shear with:
@@ -98,6 +100,8 @@ class TestDerivatives:
         ])
         print("target re-orientation rate:\n", target_orientations_diff)
         assert np.allclose(orientations_diff, target_orientations_diff)
+        print("calculated grain volume changes:\n", fractions_diff)
+        assert np.isclose(np.sum(fractions_diff), 0.0)
 
     def test_simple_shear_initP45Z(self):
         # Single grain of olivine A-type, simple shear with:
@@ -134,6 +138,8 @@ class TestDerivatives:
         ])
         print("target re-orientation rate:\n", target_orientations_diff)
         assert np.allclose(orientations_diff, target_orientations_diff)
+        print("calculated grain volume changes:\n", fractions_diff)
+        assert np.isclose(np.sum(fractions_diff), 0.0)
 
     def test_simple_shear_initP90Z(self):
         # Single grain of olivine A-type, simple shear with:
@@ -170,6 +176,8 @@ class TestDerivatives:
         ])
         print("target re-orientation rate:\n", target_orientations_diff)
         assert np.allclose(orientations_diff, target_orientations_diff)
+        print("calculated grain volume changes:\n", fractions_diff)
+        assert np.isclose(np.sum(fractions_diff), 0.0)
 
     def test_simple_shear_initP10Y(self):
         # Single grain of olivine A-type, simple shear with:
@@ -206,6 +214,8 @@ class TestDerivatives:
         ])
         print("target re-orientation rate:\n", target_orientations_diff)
         assert np.allclose(orientations_diff, target_orientations_diff)
+        print("calculated grain volume changes:\n", fractions_diff)
+        assert np.isclose(np.sum(fractions_diff), 0.0)
 
     def test_simple_shear_initN10Y(self):
         # Single grain of olivine A-type, simple shear with:
@@ -242,6 +252,8 @@ class TestDerivatives:
         ])
         print("target re-orientation rate:\n", target_orientations_diff)
         assert np.allclose(orientations_diff, target_orientations_diff)
+        print("calculated grain volume changes:\n", fractions_diff)
+        assert np.isclose(np.sum(fractions_diff), 0.0)
 
     def test_simple_shear_initP45Y(self):
         # Single grain of olivine A-type, simple shear with:
@@ -278,6 +290,8 @@ class TestDerivatives:
         ])
         print("target re-orientation rate:\n", target_orientations_diff)
         assert np.allclose(orientations_diff, target_orientations_diff)
+        print("calculated grain volume changes:\n", fractions_diff)
+        assert np.isclose(np.sum(fractions_diff), 0.0)
 
     def test_simple_shear_initP90Y(self):
         # Single grain of olivine A-type, simple shear with:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -355,10 +355,10 @@ class TestSimpleShearSingleGrains:
             gbm_mobility=125,
             volume_fraction=1.0,
         )
-        # Check that we are moving towards a 'point' symmetry (λ[0] is largest).
-        # See Vollmer 1990:
+        # Check that we are moving towards a 'point' symmetry
+        # (one eigenvalue is largest). See Vollmer 1990:
         # <https://doi.org/10.1130/0016-7606(1990)102%3C0786:aaoemt%3E2.3.co;2>.
         orientations_new = initial_orientations.as_matrix()[0] + orientations_diff[0]
-        λ = np.abs(la.eigvals(orientations_new))
-        assert λ[0] > λ[1] and np.isclose(λ[1], λ[2])
+        λ = np.sort(np.abs(la.eigvals(orientations_new)))
+        assert λ[2] > λ[1] and np.isclose(λ[1], λ[0])
         assert np.isclose(np.sum(fractions_diff), 0.0)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -360,5 +360,7 @@ class TestSimpleShearSingleGrains:
         # <https://doi.org/10.1130/0016-7606(1990)102%3C0786:aaoemt%3E2.3.co;2>.
         orientations_new = initial_orientations.as_matrix()[0] + orientations_diff[0]
         λ = np.sort(np.abs(la.eigvals(orientations_new)))
+        print("eigenvales of updated orientation matrix:\n", λ)
         assert λ[2] > λ[1] and np.isclose(λ[1], λ[0])
+        print("grain size change:\n", fractions_diff)
         assert np.isclose(np.sum(fractions_diff), 0.0)


### PR DESCRIPTION
Renaming some stuff, a new test at the end. Random initialisation for single grains is doing the right thing according to the (less strict) eigenvalue metric from Vollmer 1990.

Pushed to the wrong remote, will delete this branch after.