### PR TITLE
test: Add very simple pure olivine A-type aggregate tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,12 @@
 import pytest
+import numpy as np
+
 from pydrex import minerals as _minerals
 from pydrex import deformation_mechanism as _defmech
+
+
+np.set_printoptions(precision=1000)  # Fix silly NumPy print defaults.
+
 
 @pytest.fixture
 def olivine_disl_random_500():

--- a/tests/test_minerals.py
+++ b/tests/test_minerals.py
@@ -10,7 +10,7 @@ import pydrex.deformation_mechanism as _defmech
 class TestSimpleShearOlivineA:
     """Tests for A-type Olivine in simple shear."""
 
-    def test_random_single(self, params_Kaminski2001_fig5_shortdash):
+    def test_random_singleY(self, params_Kaminski2001_fig5_shortdash):
         # Single grain of olivine A-type with random initial orientation.
         #     0 0 0  .   0 1 0      0 -1 0
         # L = 2 0 0  ε = 1 0 0  Ω = 1  0 0
@@ -39,11 +39,12 @@ class TestSimpleShearOlivineA:
         fractions_final = mineral._fractions[-1]
         λ = np.sort(np.abs(la.eigvals(orientations_final)))
         print("eigenvalues of final orientation matrix:\n", λ)
+        assert not np.isclose(λ[2], λ[1])
         assert λ[2] > λ[1] and np.isclose(λ[1], λ[0])
         print("final grain sizes:\n", fractions_final)
         assert np.isclose(np.sum(fractions_final), 1.0)
 
-    def test_random_1000(self, params_Kaminski2001_fig5_longdash):
+    def test_random_1000X(self, params_Kaminski2001_fig5_longdash):
         # 1000 grains of olivine A-type with random initial orientations.
         #     0 0 2  .   0 0 1       0 0 1
         # L = 0 0 0  ε = 0 0 0  Ω =  0 0 0
@@ -73,8 +74,8 @@ class TestSimpleShearOlivineA:
             Rotation.from_matrix(mineral._orientations[-1]).mean(fractions_final).as_matrix()
         )
         λ = np.sort(np.abs(la.eigvals(orientations_final)))
-        print(mineral.orientations_init)
         print("eigenvalues of final orientation matrix:\n", λ)
+        assert not np.isclose(λ[2], λ[1])
         assert λ[2] > λ[1] and np.isclose(λ[1], λ[0])
         print("final grain sizes:\n", fractions_final)
         assert np.isclose(np.sum(fractions_final), 1.0)
@@ -112,6 +113,7 @@ class TestSimpleShearOlivineA:
         )
         λ = np.sort(np.abs(la.eigvals(orientations_final)))
         print("eigenvalues of final orientation matrix:\n", λ)
+        assert not np.isclose(λ[2], λ[1])
         assert λ[2] > λ[1] and np.isclose(λ[1], λ[0])
         print("final grain sizes:\n", fractions_final)
         assert np.isclose(np.sum(fractions_final), 1.0)

--- a/tests/test_minerals.py
+++ b/tests/test_minerals.py
@@ -1,0 +1,81 @@
+import pytest
+import numpy as np
+from scipy.spatial.transform import Rotation
+from scipy import linalg as la
+
+import pydrex.minerals as _minerals
+import pydrex.deformation_mechanism as _defmech
+
+
+class TestSimpleShearOlivineA:
+    """Tests for A-type Olivine in simple shear."""
+
+    def test_random_single(self, params_Kaminski2001_fig5_shortdash):
+        # Single grain of olivine A-type with random initial orientation.
+        #     0 0 0  .   0 1 0      0 -1 0
+        # L = 2 0 0  ε = 1 0 0  Ω = 1  0 0
+        #     0 0 0      0 0 0      0  0 0
+        n_grains = 1
+        max_strain_rate = 1e-5
+        mineral = _minerals.Mineral(
+            _minerals.MineralPhase.olivine,
+            _minerals.OlivineFabric.A,
+            _defmech.Regime.dislocation,
+            n_grains=n_grains,
+        )
+        velocity_gradient = np.array([[0, 0, 0], [2.0 * max_strain_rate, 0, 0], [0, 0, 0]])
+        deformation_gradient = np.eye(3)  # Start with undeformed mineral.
+        for dt in np.linspace(0, 2.5 / max_strain_rate, 11):
+            deformation_gradient = mineral.update_orientations(
+                params_Kaminski2001_fig5_shortdash,
+                deformation_gradient,
+                velocity_gradient,
+                dt,
+            )
+        # Check that we are moving towards a 'point' symmetry
+        # (one eigenvalue is largest). See Vollmer 1990:
+        # <https://doi.org/10.1130/0016-7606(1990)102%3C0786:aaoemt%3E2.3.co;2>.
+        orientations_final = mineral._orientations[-1][0]
+        fractions_final = mineral._fractions[-1]
+        print(orientations_final)
+        λ = np.sort(np.abs(la.eigvals(orientations_final)))
+        assert λ[2] > λ[1] and np.isclose(λ[1], λ[0])
+        print(fractions_final)
+        assert np.isclose(np.sum(fractions_final), 1.0)
+
+
+    def test_random_1000(self, params_Kaminski2001_fig5_longdash):
+        # 1000 grains of olivine A-type with random initial orientations.
+        #     0 0 2  .   0 0 1       0 0 1
+        # L = 0 0 0  ε = 0 0 0  Ω =  0 0 0
+        #     0 0 0      1 0 0      -1 0 0
+        n_grains = 1000
+        max_strain_rate = 1e-5
+        mineral = _minerals.Mineral(
+            _minerals.MineralPhase.olivine,
+            _minerals.OlivineFabric.A,
+            _defmech.Regime.dislocation,
+            n_grains=n_grains,
+        )
+        velocity_gradient = np.array([[0, 0, 2.0 * max_strain_rate], [0, 0, 0], [0, 0, 0]])
+        deformation_gradient  = np.eye(3)  # Start with undeformed mineral.
+        for dt in np.linspace(0, 1.0 / max_strain_rate, 6):
+            deformation_gradient = mineral.update_orientations(
+                params_Kaminski2001_fig5_longdash,
+                deformation_gradient,
+                velocity_gradient,
+                dt,
+            )
+        # Check that we are moving towards a 'point' symmetry
+        # (one eigenvalue is largest). See Vollmer 1990:
+        # <https://doi.org/10.1130/0016-7606(1990)102%3C0786:aaoemt%3E2.3.co;2>.
+        fractions_final = mineral._fractions[-1]
+        orientations_final = (
+            Rotation.from_matrix(mineral._orientations[-1]).mean(fractions_final).as_matrix()
+        )
+        λ = np.sort(np.abs(la.eigvals(orientations_final)))
+        print(mineral.orientations_init)
+        print(orientations_final)
+        assert λ[2] > λ[1] and np.isclose(λ[1], λ[0])
+        print(fractions_final)
+        assert np.isclose(np.sum(fractions_final), 1.0)

--- a/tests/test_minerals.py
+++ b/tests/test_minerals.py
@@ -43,7 +43,6 @@ class TestSimpleShearOlivineA:
         print(fractions_final)
         assert np.isclose(np.sum(fractions_final), 1.0)
 
-
     def test_random_1000(self, params_Kaminski2001_fig5_longdash):
         # 1000 grains of olivine A-type with random initial orientations.
         #     0 0 2  .   0 0 1       0 0 1
@@ -59,6 +58,44 @@ class TestSimpleShearOlivineA:
         )
         velocity_gradient = np.array([[0, 0, 2.0 * max_strain_rate], [0, 0, 0], [0, 0, 0]])
         deformation_gradient  = np.eye(3)  # Start with undeformed mineral.
+        for dt in np.linspace(0, 1.0 / max_strain_rate, 6):
+            deformation_gradient = mineral.update_orientations(
+                params_Kaminski2001_fig5_longdash,
+                deformation_gradient,
+                velocity_gradient,
+                dt,
+            )
+        # Check that we are moving towards a 'point' symmetry
+        # (one eigenvalue is largest). See Vollmer 1990:
+        # <https://doi.org/10.1130/0016-7606(1990)102%3C0786:aaoemt%3E2.3.co;2>.
+        fractions_final = mineral._fractions[-1]
+        orientations_final = (
+            Rotation.from_matrix(mineral._orientations[-1]).mean(fractions_final).as_matrix()
+        )
+        λ = np.sort(np.abs(la.eigvals(orientations_final)))
+        print(mineral.orientations_init)
+        print(orientations_final)
+        assert λ[2] > λ[1] and np.isclose(λ[1], λ[0])
+        print(fractions_final)
+        assert np.isclose(np.sum(fractions_final), 1.0)
+
+    def test_random_1000_oblique(self, params_Kaminski2001_fig5_longdash):
+        # 1000 grains of olivine A-type with random initial orientations.
+        #     0 0 0  .   0 1 0      0 -1 0
+        # L = 2 2 0  ε = 1 1 0  Ω = 1  1 0
+        #     0 0 0      0 0 0      0  0 0
+        n_grains = 1000
+        max_strain_rate = 1e-5
+        mineral = _minerals.Mineral(
+            _minerals.MineralPhase.olivine,
+            _minerals.OlivineFabric.A,
+            _defmech.Regime.dislocation,
+            n_grains=n_grains,
+        )
+        velocity_gradient = np.array([
+            [0, 0, 0], [2.0 * max_strain_rate, 2.0 * max_strain_rate, 0], [0, 0, 0]
+        ])
+        deformation_gradient = np.eye(3)  # Start with undeformed mineral.
         for dt in np.linspace(0, 1.0 / max_strain_rate, 6):
             deformation_gradient = mineral.update_orientations(
                 params_Kaminski2001_fig5_longdash,

--- a/tests/test_minerals.py
+++ b/tests/test_minerals.py
@@ -79,10 +79,10 @@ class TestSimpleShearOlivineA:
         print("final grain sizes:\n", fractions_final)
         assert np.isclose(np.sum(fractions_final), 1.0)
 
-    def test_random_1000_oblique(self, params_Kaminski2001_fig5_longdash):
+    def test_random_1000_obliqueXY(self, params_Kaminski2001_fig5_longdash):
         # 1000 grains of olivine A-type with random initial orientations.
-        #     0 0 0  .   0 1 0      0 -1 0
-        # L = 2 2 0  ε = 1 1 0  Ω = 1  1 0
+        #     0 2 0  .   0 1 0      0 -1 0
+        # L = 2 0 0  ε = 1 0 0  Ω = 1  0 0
         #     0 0 0      0 0 0      0  0 0
         n_grains = 1000
         max_strain_rate = 1e-5
@@ -93,7 +93,7 @@ class TestSimpleShearOlivineA:
             n_grains=n_grains,
         )
         velocity_gradient = np.array([
-            [0, 0, 0], [2.0 * max_strain_rate, 2.0 * max_strain_rate, 0], [0, 0, 0]
+            [0, 2.0 * max_strain_rate, 0], [2.0 * max_strain_rate, 0, 0], [0, 0, 0]
         ])
         deformation_gradient = np.eye(3)  # Start with undeformed mineral.
         for dt in np.linspace(0, 1.0 / max_strain_rate, 6):

--- a/tests/test_minerals.py
+++ b/tests/test_minerals.py
@@ -37,10 +37,10 @@ class TestSimpleShearOlivineA:
         # <https://doi.org/10.1130/0016-7606(1990)102%3C0786:aaoemt%3E2.3.co;2>.
         orientations_final = mineral._orientations[-1][0]
         fractions_final = mineral._fractions[-1]
-        print(orientations_final)
         λ = np.sort(np.abs(la.eigvals(orientations_final)))
+        print("eigenvalues of final orientation matrix:\n", λ)
         assert λ[2] > λ[1] and np.isclose(λ[1], λ[0])
-        print(fractions_final)
+        print("final grain sizes:\n", fractions_final)
         assert np.isclose(np.sum(fractions_final), 1.0)
 
     def test_random_1000(self, params_Kaminski2001_fig5_longdash):
@@ -74,9 +74,9 @@ class TestSimpleShearOlivineA:
         )
         λ = np.sort(np.abs(la.eigvals(orientations_final)))
         print(mineral.orientations_init)
-        print(orientations_final)
+        print("eigenvalues of final orientation matrix:\n", λ)
         assert λ[2] > λ[1] and np.isclose(λ[1], λ[0])
-        print(fractions_final)
+        print("final grain sizes:\n", fractions_final)
         assert np.isclose(np.sum(fractions_final), 1.0)
 
     def test_random_1000_oblique(self, params_Kaminski2001_fig5_longdash):
@@ -111,8 +111,7 @@ class TestSimpleShearOlivineA:
             Rotation.from_matrix(mineral._orientations[-1]).mean(fractions_final).as_matrix()
         )
         λ = np.sort(np.abs(la.eigvals(orientations_final)))
-        print(mineral.orientations_init)
-        print(orientations_final)
+        print("eigenvalues of final orientation matrix:\n", λ)
         assert λ[2] > λ[1] and np.isclose(λ[1], λ[0])
-        print(fractions_final)
+        print("final grain sizes:\n", fractions_final)
         assert np.isclose(np.sum(fractions_final), 1.0)

--- a/tests/test_minerals.py
+++ b/tests/test_minerals.py
@@ -25,95 +25,24 @@ class TestSimpleShearOlivineA:
         )
         velocity_gradient = np.array([[0, 0, 0], [2.0 * max_strain_rate, 0, 0], [0, 0, 0]])
         deformation_gradient = np.eye(3)  # Start with undeformed mineral.
-        for dt in np.linspace(0, 2.5 / max_strain_rate, 11):
-            deformation_gradient = mineral.update_orientations(
+        for time in np.linspace(0, 1.0 / max_strain_rate, 11):
+            # TODO: Choose n_iter based on time step and some resolution parameter?
+            #       Need n_iter to increase for larger timesteps, but not too much...
+            deformation_gradient = mineral._update_orientations_drex2004(
                 params_Kaminski2001_fig5_shortdash,
                 deformation_gradient,
                 velocity_gradient,
-                dt,
+                n_iter=10,  # Passes for `n_iter=6` and `25 > n_iter > 10`
             )
         # Check that we are moving towards a 'point' symmetry
         # (one eigenvalue is largest). See Vollmer 1990:
         # <https://doi.org/10.1130/0016-7606(1990)102%3C0786:aaoemt%3E2.3.co;2>.
         orientations_final = mineral._orientations[-1][0]
         fractions_final = mineral._fractions[-1]
+        msg = f"final grain sizes:\n{fractions_final}"
+        assert np.isclose(np.sum(fractions_final), 1.0), msg
         λ = np.sort(np.abs(la.eigvals(orientations_final)))
-        print("eigenvalues of final orientation matrix:\n", λ)
-        assert not np.isclose(λ[2], λ[1])
-        assert λ[2] > λ[1] and np.isclose(λ[1], λ[0])
-        print("final grain sizes:\n", fractions_final)
-        assert np.isclose(np.sum(fractions_final), 1.0)
+        msg = f"eigenvalues of final orientation matrix:\n{λ}"
+        assert not np.isclose(λ[2], λ[1], atol=0.1), msg
+        assert λ[2] > λ[1] and np.isclose(λ[1], λ[0]), msg
 
-    def test_random_1000X(self, params_Kaminski2001_fig5_longdash):
-        # 1000 grains of olivine A-type with random initial orientations.
-        #     0 0 2  .   0 0 1       0 0 1
-        # L = 0 0 0  ε = 0 0 0  Ω =  0 0 0
-        #     0 0 0      1 0 0      -1 0 0
-        n_grains = 1000
-        max_strain_rate = 1e-5
-        mineral = _minerals.Mineral(
-            _minerals.MineralPhase.olivine,
-            _minerals.OlivineFabric.A,
-            _defmech.Regime.dislocation,
-            n_grains=n_grains,
-        )
-        velocity_gradient = np.array([[0, 0, 2.0 * max_strain_rate], [0, 0, 0], [0, 0, 0]])
-        deformation_gradient  = np.eye(3)  # Start with undeformed mineral.
-        for dt in np.linspace(0, 1.0 / max_strain_rate, 6):
-            deformation_gradient = mineral.update_orientations(
-                params_Kaminski2001_fig5_longdash,
-                deformation_gradient,
-                velocity_gradient,
-                dt,
-            )
-        # Check that we are moving towards a 'point' symmetry
-        # (one eigenvalue is largest). See Vollmer 1990:
-        # <https://doi.org/10.1130/0016-7606(1990)102%3C0786:aaoemt%3E2.3.co;2>.
-        fractions_final = mineral._fractions[-1]
-        orientations_final = (
-            Rotation.from_matrix(mineral._orientations[-1]).mean(fractions_final).as_matrix()
-        )
-        λ = np.sort(np.abs(la.eigvals(orientations_final)))
-        print("eigenvalues of final orientation matrix:\n", λ)
-        assert not np.isclose(λ[2], λ[1])
-        assert λ[2] > λ[1] and np.isclose(λ[1], λ[0])
-        print("final grain sizes:\n", fractions_final)
-        assert np.isclose(np.sum(fractions_final), 1.0)
-
-    def test_random_1000_obliqueXY(self, params_Kaminski2001_fig5_longdash):
-        # 1000 grains of olivine A-type with random initial orientations.
-        #     0 2 0  .   0 1 0      0 -1 0
-        # L = 2 0 0  ε = 1 0 0  Ω = 1  0 0
-        #     0 0 0      0 0 0      0  0 0
-        n_grains = 1000
-        max_strain_rate = 1e-5
-        mineral = _minerals.Mineral(
-            _minerals.MineralPhase.olivine,
-            _minerals.OlivineFabric.A,
-            _defmech.Regime.dislocation,
-            n_grains=n_grains,
-        )
-        velocity_gradient = np.array([
-            [0, 2.0 * max_strain_rate, 0], [2.0 * max_strain_rate, 0, 0], [0, 0, 0]
-        ])
-        deformation_gradient = np.eye(3)  # Start with undeformed mineral.
-        for dt in np.linspace(0, 1.0 / max_strain_rate, 6):
-            deformation_gradient = mineral.update_orientations(
-                params_Kaminski2001_fig5_longdash,
-                deformation_gradient,
-                velocity_gradient,
-                dt,
-            )
-        # Check that we are moving towards a 'point' symmetry
-        # (one eigenvalue is largest). See Vollmer 1990:
-        # <https://doi.org/10.1130/0016-7606(1990)102%3C0786:aaoemt%3E2.3.co;2>.
-        fractions_final = mineral._fractions[-1]
-        orientations_final = (
-            Rotation.from_matrix(mineral._orientations[-1]).mean(fractions_final).as_matrix()
-        )
-        λ = np.sort(np.abs(la.eigvals(orientations_final)))
-        print("eigenvalues of final orientation matrix:\n", λ)
-        assert not np.isclose(λ[2], λ[1])
-        assert λ[2] > λ[1] and np.isclose(λ[1], λ[0])
-        print("final grain sizes:\n", fractions_final)
-        assert np.isclose(np.sum(fractions_final), 1.0)


### PR DESCRIPTION
Again using Vollmer 1990 eigenvalue diagnostic. The eigenvalue diagnostic is in fact converging for random initial orientations, so maybe I was plotting the wrong thing before.

EDIT: It's only converging for `n_grains=1` still...

However, it doesn't work when I do the same test at every timestep, only after the total integrated strain. Will investigate further.