### PR TITLE
Texture diagnostics

### DIFF
--- a/src/pydrex/diagnostics.py
+++ b/src/pydrex/diagnostics.py
@@ -165,7 +165,12 @@ def misorientation_angles(combinations):
         np.arccos(
             np.clip(
                 (
-                    np.trace(combinations[:, 0] @ combinations[:, 1], axis1=1, axis2=2)
+                    np.trace(
+                        combinations[:, 0]
+                        @ np.transpose(combinations[:, 1], axes=[0, 2, 1]),
+                        axis1=1,
+                        axis2=2,
+                    )
                     - 1.0
                 )
                 / 2,

--- a/src/pydrex/diagnostics.py
+++ b/src/pydrex/diagnostics.py
@@ -20,6 +20,7 @@ import itertools as it
 
 import numba as nb
 import numpy as np
+from numpy import random as rn
 import scipy.linalg as la
 import scipy.special as sp
 

--- a/src/pydrex/diagnostics.py
+++ b/src/pydrex/diagnostics.py
@@ -1,7 +1,7 @@
 """PyDRex: Methods to calculate texture diagnostics.
 
-NOTE: Calculations expect orientation matrices $a$ to represent passive,
-i.e. alias rotations, which are defined in terms of the extrinsic ZXZ
+NOTE: Calculations expect orientation matrices $a$ to represent passive
+(i.e. alias) rotations, which are defined in terms of the extrinsic ZXZ
 euler angles $ϕ, θ, φ$ as
 
 $$
@@ -12,7 +12,7 @@ a = \begin{bmatrix}
     \\end{bmatrix}
 $$
 
-such that a[i,j] gives the direction cosine of the angle between the i-th
+such that a[i, j] gives the direction cosine of the angle between the i-th
 grain axis and the j-th external axis (in the global Eulerian frame).
 
 """
@@ -51,8 +51,8 @@ def bingham_average(orientations, axis="a"):
     # Eigenvector corresponding to largest eigenvalue is the mean direction.
     # SciPy returns eigenvalues in ascending order (same order for vectors).
     mean_vector = la.eigh(_scatter_matrix(orientations, row))[1][:, -1]
-    # Use abs because the mean vector [a, a, a] and [-a, -a, -a] are the same.
-    # This way the output form arccos is more consistent for measuring alignment.
+    # Use abs because the mean vectors [a, a, a] and [-a, -a, -a] are the same.
+    # This way the output from arccos is more consistent for measuring alignment.
     return np.abs(mean_vector / la.norm(mean_vector))
 
 
@@ -154,9 +154,9 @@ def misorientation_index(orientations):
 
 
 def misorientation_angles(combinations):
-    """Calculate the misorientation angles for a pairs of rotation matrices.
+    """Calculate the misorientation angles for pairs of rotation matrices.
 
-    Calculate the angles of the difference rotations between `combinations[:, 0]`
+    Calculate the angular distance between the rotations `combinations[:, 0]`
     and `combinations[:, 1]`, which are expected to be 3x3 passive (alias)
     rotation matrices.
 
@@ -279,7 +279,7 @@ def smallest_angle(vector, axis):
     The axis is specified using either of its two parallel unit vectors.
 
     """
-    angle = np.rad2deg(np.arccos(np.dot(vector, axis)))
+    angle = np.abs(np.rad2deg(np.arccos(np.dot(vector, axis))))
     if angle > 90:
         return 180 - angle
     return angle

--- a/src/pydrex/diagnostics.py
+++ b/src/pydrex/diagnostics.py
@@ -20,9 +20,9 @@ import itertools as it
 
 import numba as nb
 import numpy as np
-from numpy import random as rn
 import scipy.linalg as la
 import scipy.special as sp
+from numpy import random as rn
 
 
 def bingham_average(orientations, axis="a"):

--- a/src/pydrex/diagnostics.py
+++ b/src/pydrex/diagnostics.py
@@ -1,8 +1,27 @@
+"""PyDRex: Methods to calculate texture diagnostics.
+
+NOTE: Calculations expect orientation matrices $a$ to represent passive,
+i.e. alias rotations, which are defined in terms of the extrinsic ZXZ
+euler angles $ϕ, θ, φ$ as
+
+$$
+a = \begin{bmatrix}
+    \cosφ\cosϕ - \cosθ\sinϕ\sinφ & \cosθ\cosϕ\sinφ + \cosφ\sinϕ & \sinφ\sinθ
+   -\sinφ\cosϕ - \cosθ\sinϕ\cosφ & \cosθ\cosϕ\cosφ - \sinφ\sinϕ & \cosφ\sinθ
+            \sinθ\sinϕ           &           -\sinθ\cosϕ        &   \cosθ
+    \end{bmatrix}
+$$
+
+such that a[i,j] gives the direction cosine of the angle between the i-th
+grain axis and the j-th external axis (in the global Eulerian frame).
+
+"""
 import itertools as it
 
 import numpy as np
 import scipy.linalg as la
-from numpy import random as rn
+import scipy.special as sp
+import numba as nb
 
 
 def bingham_average(orientations, axis="a"):
@@ -31,7 +50,9 @@ def bingham_average(orientations, axis="a"):
     # Eigenvector corresponding to largest eigenvalue is the mean direction.
     # SciPy returns eigenvalues in ascending order (same order for vectors).
     mean_vector = la.eigh(_scatter_matrix(orientations, row))[1][:, -1]
-    return mean_vector / la.norm(mean_vector)
+    # Use abs because the mean vector [a, a, a] and [-a, -a, -a] are the same.
+    # This way the output form arccos is more consistent for measuring alignment.
+    return np.abs(mean_vector / la.norm(mean_vector))
 
 
 def symmetry(orientations, axis="a"):
@@ -115,9 +136,9 @@ def misorientation_index(orientations):
     [Skemer et al. 2005]: https://doi.org/10.1016/j.tecto.2005.08.023
 
     """
-    misorientations = [
-        misorientation_angle(A, B) for A, B in it.combinations(orientations, 2)
-    ]
+    misorientations = misorientation_angles(
+        np.array(list(it.combinations(orientations, 2)))
+    )
     # Number of misorientations within 1° bins.
     count_misorientations, _ = np.histogram(misorientations, bins=120, range=(0, 120))
     return (1 / 2 / len(misorientations)) * np.sum(
@@ -131,16 +152,27 @@ def misorientation_index(orientations):
     )
 
 
-def misorientation_angle(rot_a, rot_b):
-    """Calculate the misorientation angle for a pair of rotation matrices.
+def misorientation_angles(combinations):
+    """Calculate the misorientation angles for a pairs of rotation matrices.
 
-    Calculate the angle of the difference rotation between `rot_a` and `rot_b`,
-    which are expected to be 3x3 rotation matrices.
+    Calculate the angles of the difference rotations between `combinations[:, 0]`
+    and `combinations[:, 1]`, which are expected to be 3x3 passive (alias)
+    rotation matrices.
 
     """
-    diff_rot = rot_a @ rot_b.T
-    # Need to clip to [-1, 1] to avoid NaNs from np.arccos due to rounding errs.
-    return np.rad2deg(np.arccos(np.clip(np.abs(np.trace(diff_rot) - 1) / 2, -1, 1)))
+    return np.rad2deg(
+        np.arccos(
+            np.clip(
+                (
+                    np.trace(combinations[:, 0] @ combinations[:, 1], axis1=1, axis2=2)
+                    - 1.0
+                )
+                / 2,
+                -1.0,
+                1.0,
+            )
+        )
+    )
 
 
 def misorientations_random(low, high, symmetry=(2, 4)):
@@ -233,3 +265,15 @@ def misorientations_random(low, high, symmetry=(2, 4)):
             assert False  # Should never happen.
 
     return np.sum(counts_both) / 2
+
+
+def smallest_angle(vector, axis):
+    """Get smallest angle between a unit `vector` and a bidirectional `axis`.
+
+    The axis is specified using either of its two parallel unit vectors.
+
+    """
+    angle = np.rad2deg(np.arccos(np.dot(vector, axis)))
+    if angle > 90:
+        return 180 - angle
+    return angle

--- a/src/pydrex/diagnostics.py
+++ b/src/pydrex/diagnostics.py
@@ -6,10 +6,10 @@ euler angles $ϕ, θ, φ$ as
 
 $$
 a = \begin{bmatrix}
-    \cosφ\cosϕ - \cosθ\sinϕ\sinφ & \cosθ\cosϕ\sinφ + \cosφ\sinϕ & \sinφ\sinθ
-   -\sinφ\cosϕ - \cosθ\sinϕ\cosφ & \cosθ\cosϕ\cosφ - \sinφ\sinϕ & \cosφ\sinθ
-            \sinθ\sinϕ           &           -\sinθ\cosϕ        &   \cosθ
-    \end{bmatrix}
+    \\cosφ\\cosϕ - \\cosθ\\sinϕ\\sinφ & \\cosθ\\cosϕ\\sinφ + \\cosφ\\sinϕ & \\sinφ\\sinθ
+   -\\sinφ\\cosϕ - \\cosθ\\sinϕ\\cosφ & \\cosθ\\cosϕ\\cosφ - \\sinφ\\sinϕ & \\cosφ\\sinθ
+            \\sinθ\\sinϕ           &           -\\sinθ\\cosϕ        &   \\cosθ
+    \\end{bmatrix}
 $$
 
 such that a[i,j] gives the direction cosine of the angle between the i-th
@@ -18,10 +18,10 @@ grain axis and the j-th external axis (in the global Eulerian frame).
 """
 import itertools as it
 
+import numba as nb
 import numpy as np
 import scipy.linalg as la
 import scipy.special as sp
-import numba as nb
 
 
 def bingham_average(orientations, axis="a"):

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -11,14 +11,18 @@ class TestSymmetryPGR:
     def test_pointX(self):
         """Test diagnostics of point symmetry aligned to the X axis."""
         # Initial orientations within 10°.
-        orientations = Rotation.from_rotvec(
-            np.stack(
-                [
-                    [0, x * np.pi / 18 - np.pi / 36, x * np.pi / 18 - np.pi / 36]
-                    for x in rn.default_rng().random(100)
-                ]
+        orientations = (
+            Rotation.from_rotvec(
+                np.stack(
+                    [
+                        [0, x * np.pi / 18 - np.pi / 36, x * np.pi / 18 - np.pi / 36]
+                        for x in rn.default_rng().random(100)
+                    ]
+                )
             )
-        ).inv().as_matrix()
+            .inv()
+            .as_matrix()
+        )
         np.testing.assert_allclose(
             _diagnostics.symmetry(orientations, axis="a"), (1, 0, 0), atol=0.4e-1
         )
@@ -38,13 +42,17 @@ class TestVolumeWeighting:
 
     def test_upsample(self):
         """Test upsampling of the raw orientation data."""
-        orientations = Rotation.from_rotvec(
-            [
-                [0, 0, 0],
-                [0, 0, np.pi / 6],
-                [np.pi / 6, 0, 0],
-            ]
-        ).inv().as_matrix()
+        orientations = (
+            Rotation.from_rotvec(
+                [
+                    [0, 0, 0],
+                    [0, 0, np.pi / 6],
+                    [np.pi / 6, 0, 0],
+                ]
+            )
+            .inv()
+            .as_matrix()
+        )
         fractions = np.array([0.25, 0.6, 0.15])
         new_orientations = _diagnostics.resample_orientations(
             orientations,
@@ -55,13 +63,17 @@ class TestVolumeWeighting:
 
     def test_downsample(self):
         """Test downsampling of orientation data."""
-        orientations = Rotation.from_rotvec(
-            [
-                [0, 0, 0],
-                [0, 0, np.pi / 6],
-                [np.pi / 6, 0, 0],
-            ]
-        ).inv().as_matrix()
+        orientations = (
+            Rotation.from_rotvec(
+                [
+                    [0, 0, 0],
+                    [0, 0, np.pi / 6],
+                    [np.pi / 6, 0, 0],
+                ]
+            )
+            .inv()
+            .as_matrix()
+        )
         fractions = np.array([0.25, 0.6, 0.15])
         new_orientations = _diagnostics.resample_orientations(
             orientations,
@@ -86,12 +98,16 @@ class TestbinghamStats:
 
     def test_average_twopoles90Z(self):
         """Test bingham average of vectors rotated by ±90° around Z."""
-        orientations = Rotation.from_rotvec(
-            [
-                [0, 0, -np.pi / 2],
-                [0, 0, np.pi / 2],
-            ]
-        ).inv().as_matrix()
+        orientations = (
+            Rotation.from_rotvec(
+                [
+                    [0, 0, -np.pi / 2],
+                    [0, 0, np.pi / 2],
+                ]
+            )
+            .inv()
+            .as_matrix()
+        )
         a_mean = _diagnostics.bingham_average(orientations, axis="a")
         b_mean = _diagnostics.bingham_average(orientations, axis="b")
         c_mean = _diagnostics.bingham_average(orientations, axis="c")
@@ -101,14 +117,18 @@ class TestbinghamStats:
 
     def test_average_spread10X(self):
         """Test bingham average of vectors spread within 10° of the ±X-axis."""
-        orientations = Rotation.from_rotvec(
-            np.stack(
-                [
-                    [0, x * np.pi / 18 - np.pi / 36, x * np.pi / 18 - np.pi / 36]
-                    for x in rn.default_rng().random(100)
-                ]
+        orientations = (
+            Rotation.from_rotvec(
+                np.stack(
+                    [
+                        [0, x * np.pi / 18 - np.pi / 36, x * np.pi / 18 - np.pi / 36]
+                        for x in rn.default_rng().random(100)
+                    ]
+                )
             )
-        ).inv().as_matrix()
+            .inv()
+            .as_matrix()
+        )
         a_mean = _diagnostics.bingham_average(orientations, axis="a")
         b_mean = _diagnostics.bingham_average(orientations, axis="b")
         c_mean = _diagnostics.bingham_average(orientations, axis="c")
@@ -129,28 +149,36 @@ class TestMIndex:
 
     def test_texture_spread10X(self):
         """Test M-index for grains spread within 10° of the ±X axis."""
-        orientations = Rotation.from_rotvec(
-            np.stack(
-                [
-                    [0, x * np.pi / 18 - np.pi / 36, x * np.pi / 18 - np.pi / 36]
-                    for x in rn.default_rng().random(100)
-                ]
+        orientations = (
+            Rotation.from_rotvec(
+                np.stack(
+                    [
+                        [0, x * np.pi / 18 - np.pi / 36, x * np.pi / 18 - np.pi / 36]
+                        for x in rn.default_rng().random(100)
+                    ]
+                )
             )
-        ).inv().as_matrix()
+            .inv()
+            .as_matrix()
+        )
         assert np.isclose(
             _diagnostics.misorientation_index(orientations), 0.99, atol=1e-2
         )
 
     def test_texture_spread30X(self):
         """Test M-index for grains spread within 45° of the ±X axis."""
-        orientations = Rotation.from_rotvec(
-            np.stack(
-                [
-                    [0, x * np.pi / 4 - np.pi / 8, x * np.pi / 4 - np.pi / 8]
-                    for x in rn.default_rng().random(100)
-                ]
+        orientations = (
+            Rotation.from_rotvec(
+                np.stack(
+                    [
+                        [0, x * np.pi / 4 - np.pi / 8, x * np.pi / 4 - np.pi / 8]
+                        for x in rn.default_rng().random(100)
+                    ]
+                )
             )
-        ).inv().as_matrix()
+            .inv()
+            .as_matrix()
+        )
         assert np.isclose(
             _diagnostics.misorientation_index(orientations), 0.8, atol=0.1
         )
@@ -160,18 +188,22 @@ class TestMIndex:
         M_vals = np.empty(4)
         factors = (2, 4, 8, 16)
         for i, factor in enumerate(factors):
-            orientations = Rotation.from_rotvec(
-                np.stack(
-                    [
+            orientations = (
+                Rotation.from_rotvec(
+                    np.stack(
                         [
-                            0,
-                            x * np.pi / factor - np.pi / factor / 2,
-                            x * np.pi / factor - np.pi / factor / 2,
+                            [
+                                0,
+                                x * np.pi / factor - np.pi / factor / 2,
+                                x * np.pi / factor - np.pi / factor / 2,
+                            ]
+                            for x in rn.default_rng().random(500)
                         ]
-                        for x in rn.default_rng().random(500)
-                    ]
+                    )
                 )
-            ).inv().as_matrix()
+                .inv()
+                .as_matrix()
+            )
             M_vals[i] = _diagnostics.misorientation_index(orientations)
         assert np.all(
             np.diff(M_vals) >= 0

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from numpy import random as rn
 from pydrex import diagnostics as _diagnostics
 from scipy.spatial.transform import Rotation

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -18,7 +18,7 @@ class TestSymmetryPGR:
                     for x in rn.default_rng().random(100)
                 ]
             )
-        ).as_matrix()
+        ).inv().as_matrix()
         np.testing.assert_allclose(
             _diagnostics.symmetry(orientations, axis="a"), (1, 0, 0), atol=0.4e-1
         )
@@ -44,7 +44,7 @@ class TestVolumeWeighting:
                 [0, 0, np.pi / 6],
                 [np.pi / 6, 0, 0],
             ]
-        ).as_matrix()
+        ).inv().as_matrix()
         fractions = np.array([0.25, 0.6, 0.15])
         new_orientations = _diagnostics.resample_orientations(
             orientations,
@@ -61,7 +61,7 @@ class TestVolumeWeighting:
                 [0, 0, np.pi / 6],
                 [np.pi / 6, 0, 0],
             ]
-        ).as_matrix()
+        ).inv().as_matrix()
         fractions = np.array([0.25, 0.6, 0.15])
         new_orientations = _diagnostics.resample_orientations(
             orientations,
@@ -76,7 +76,7 @@ class TestbinghamStats:
 
     def test_average_0(self):
         """Test bingham average of vectors aligned to the reference frame."""
-        orientations = Rotation.from_rotvec([[0, 0, 0]] * 10).as_matrix()
+        orientations = Rotation.from_rotvec([[0, 0, 0]] * 10).inv().as_matrix()
         a_mean = _diagnostics.bingham_average(orientations, axis="a")
         b_mean = _diagnostics.bingham_average(orientations, axis="b")
         c_mean = _diagnostics.bingham_average(orientations, axis="c")
@@ -91,7 +91,7 @@ class TestbinghamStats:
                 [0, 0, -np.pi / 2],
                 [0, 0, np.pi / 2],
             ]
-        ).as_matrix()
+        ).inv().as_matrix()
         a_mean = _diagnostics.bingham_average(orientations, axis="a")
         b_mean = _diagnostics.bingham_average(orientations, axis="b")
         c_mean = _diagnostics.bingham_average(orientations, axis="c")
@@ -108,7 +108,7 @@ class TestbinghamStats:
                     for x in rn.default_rng().random(100)
                 ]
             )
-        ).as_matrix()
+        ).inv().as_matrix()
         a_mean = _diagnostics.bingham_average(orientations, axis="a")
         b_mean = _diagnostics.bingham_average(orientations, axis="b")
         c_mean = _diagnostics.bingham_average(orientations, axis="c")
@@ -124,7 +124,7 @@ class TestMIndex:
         """Test M-index for random (uniform distribution) grain orientations."""
         orientations = Rotation.random(1000).as_matrix()
         assert np.isclose(
-            _diagnostics.misorientation_index(orientations), 0.44, atol=1e-2
+            _diagnostics.misorientation_index(orientations), 0.38, atol=1e-2
         )
 
     def test_texture_spread10X(self):
@@ -136,7 +136,7 @@ class TestMIndex:
                     for x in rn.default_rng().random(100)
                 ]
             )
-        ).as_matrix()
+        ).inv().as_matrix()
         assert np.isclose(
             _diagnostics.misorientation_index(orientations), 0.99, atol=1e-2
         )
@@ -150,7 +150,7 @@ class TestMIndex:
                     for x in rn.default_rng().random(100)
                 ]
             )
-        ).as_matrix()
+        ).inv().as_matrix()
         assert np.isclose(
             _diagnostics.misorientation_index(orientations), 0.8, atol=0.1
         )
@@ -171,7 +171,7 @@ class TestMIndex:
                         for x in rn.default_rng().random(500)
                     ]
                 )
-            ).as_matrix()
+            ).inv().as_matrix()
             M_vals[i] = _diagnostics.misorientation_index(orientations)
         assert np.all(
             np.diff(M_vals) >= 0


### PR DESCRIPTION
The calculation can take a long time with loops.
For 1000 grains there are 499500 matrix multiplications.
Vectorized, it is fast enough to use in tests (at least for one polycrystal).
Numba could be necessary for larger tests, we'll see.
Also added module docs and a few small extras.