### PR TITLE
GBS test and small test fixes

### DIFF
--- a/src/pydrex/visualisation.py
+++ b/src/pydrex/visualisation.py
@@ -58,7 +58,9 @@ def simple_shear_2d(
             timesteps,
             refval * np.exp(timesteps * (np.cos(np.deg2rad(refval * 2)) - 1)),
             "r--",
-            label=r"$θ ⋅ \exp[t ⋅ (\cos2θ - 1)]$," + "\n\t" + fr"$\theta = {refval:.1f}$",
+            label=r"$θ ⋅ \exp[t ⋅ (\cos2θ - 1)]$,"
+            + "\n\t"
+            + rf"$\theta = {refval:.1f}$",
         )
 
     if labels is not None:

--- a/src/pydrex/visualisation.py
+++ b/src/pydrex/visualisation.py
@@ -58,6 +58,7 @@ def simple_shear_2d(
             timesteps,
             refval * np.exp(timesteps * (np.cos(np.deg2rad(refval * 2)) - 1)),
             "r--",
+            label=r"$θ ⋅ \exp[t ⋅ (\cos2θ - 1)]$," + "\n\t" + fr"$\theta = {refval:.1f}$",
         )
 
     if labels is not None:

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,13 @@
+# PyDRex tests
+
+Running the tests requires [pytest](https://docs.pytest.org).
+From the root of the source tree, run `pytest`.
+The custom optional flag `--outdir="OUT"` can be used
+to produce output figures and save them in the directory `"OUT"`.
+The value `"."` can be used to save figures in the current directory.
+
+Tests should not produce figures by default.
+If a test method can produce figures, it should accept the `outdir`
+positional argument, and check if its value is not `None`.
+If `outdir is None` then no figures should be produced.
+This also applies to any other large outputs like verbose logs or data dumps.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,32 +18,6 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture
-def olivine_disl_random_500():
-    return [
-        _minerals.Mineral(
-            _minerals.MineralPhase.olivine,
-            fabric,
-            _defmech.Regime.dislocation,
-            500,
-        )
-        for fabric in _minerals.OlivineFabric
-    ]
-
-
-@pytest.fixture
-def enstatite_disl_random_500():
-    return [
-        _minerals.Mineral(
-            _minerals.MineralPhase.enstatite,
-            fabric,
-            _defmech.Regime.dislocation,
-            500,
-        )
-        for fabric in _minerals.EnstatiteFabric
-    ]
-
-
-@pytest.fixture
 def params_Fraters2021():
     return {
         "stress_exponent": 3.5,

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -128,7 +128,7 @@ class TestSinglePolycrystalOlivineA:
                 )
 
             # Check for uncorrupted record of initial condition.
-            assert np.isclose(misorient_angles[0], 45.0, atol=4.5)
+            assert np.isclose(misorient_angles[0], 45.0, atol=5.0)
             assert misorient_indices[0] < 0.7
             # Check for mostly smoothly decreasing misalignment.
             angles_diff = np.diff(misorient_angles)
@@ -142,12 +142,12 @@ class TestSinglePolycrystalOlivineA:
                 case 0:
                     np.testing.assert_allclose(
                         misorient_angles,
-                        45
+                        misorient_angles[0]
                         * np.exp(
                             np.linspace(0, timestop, n_timesteps)
-                            * (np.cos(np.pi / 2) - 1)
+                            * (np.cos(2 * np.deg2rad(misorient_angles[0])) - 1)
                         ),
-                        atol=3.0,
+                        atol=5.0,
                     )
                     assert np.isclose(misorient_angles[halfway], 25, atol=2.0)
                     assert np.isclose(misorient_angles[-1], 17.0, atol=1.0)

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -181,3 +181,162 @@ class TestSinglePolycrystalOlivineA:
                 labels=labels,
                 refval=45,
             )
+
+    def test_shearXZ_initQ1(
+        self,
+        params_Kaminski2004_fig4_triangles,  # GBS = 0.4
+        params_Kaminski2004_fig4_squares,  # GBS = 0.2
+        params_Kaminski2004_fig4_circles,  # GBS = 0
+        outdir,
+    ):
+        """Test clockwise a-axis rotation around Y.
+
+        Initial condition: randomised a-axis orientation within the first
+        quadrant (between +X and +Z axes) and steady flow with velocity gradient
+
+                0 0 2
+            L = 0 0 0
+                0 0 0
+
+        Orientations set up for slip on (010)[100].
+
+        """
+        strain_rate_scale = 2e-5
+        velocity_gradient = np.zeros((3, 3))
+        velocity_gradient[0, 2] = strain_rate_scale
+        timescale = 1 / (strain_rate_scale / 2)
+        n_grains = 1000
+
+        # Initial orientations with a-axis in first quadrant of the XZ plane,
+        # and c-axis along the -Y direction (important!)
+        # This means that the starting average is the same,
+        # which is convenient for comparing the texture evolution.
+        orientations_init = (
+            Rotation.from_euler(
+                "zxz",
+                [
+                    [x * np.pi / 2, np.pi / 2, 0]
+                    for x in rn.default_rng().random(n_grains)
+                ],
+            )
+            .inv()
+            .as_matrix()
+        )
+        # Uncomment to check a-axis vectors, should be near [a, 0, a].
+        # assert False, f"{orientations_init[0:10, 0, :]}"
+        # Uncomment to check c-axis vectors, should be near [0, -1, 0].
+        # assert False, f"{orientations_init[0:10, 2, :]}"
+
+        # One mineral to test each grain boundary sliding threshold.
+        minerals = [
+            _minerals.Mineral(
+                _minerals.MineralPhase.olivine,
+                _minerals.OlivineFabric.A,
+                _defmech.Regime.dislocation,
+                n_grains=n_grains,
+                fractions_init=np.full(n_grains, 1 / n_grains),
+                orientations_init=orientations_init,
+            )
+            for i in range(3)
+        ]
+
+        # Optional plotting setup.
+        if outdir is not None:
+            labels = []
+            angles = []
+            indices = []
+
+        for mineral, params in zip(
+            minerals,
+            (
+                params_Kaminski2004_fig4_triangles,  # GBS = 0.4
+                params_Kaminski2004_fig4_squares,  # GBS = 0.2
+                params_Kaminski2004_fig4_circles,  # GBS = 0
+            ),
+        ):
+            time = 0
+            timestep = 0.025
+            timestop = 1
+            deformation_gradient = np.eye(3)  # Undeformed initial state.
+            while time < timestop * timescale:
+                deformation_gradient = mineral.update_orientations(
+                    params,
+                    deformation_gradient,
+                    velocity_gradient,
+                    integration_time=timestep * timescale,
+                )
+                time += timestep * timescale
+
+            n_timesteps = len(mineral._orientations)
+            misorient_angles = np.zeros(n_timesteps)
+            misorient_indices = np.zeros(n_timesteps)
+            # Loop over first dimension (time steps) of orientations.
+            for idx, matrices in enumerate(mineral._orientations):
+                orientations_resampled, _ = _diagnostics.resample_orientations(
+                    matrices, mineral._fractions[idx]
+                )
+                direction_mean = _diagnostics.bingham_average(
+                    orientations_resampled,
+                    axis=_minerals.get_primary_axis(mineral.fabric),
+                )
+                misorient_angles[idx] = _diagnostics.smallest_angle(
+                    direction_mean, [1, 0, 0]
+                )
+                misorient_indices[idx] = _diagnostics.misorientation_index(
+                    orientations_resampled
+                )
+
+            # Check for uncorrupted record of initial condition.
+            assert np.isclose(misorient_angles[0], 45.0, atol=5.0)
+            assert misorient_indices[0] < 0.7
+            # Check for mostly smoothly decreasing misalignment.
+            angles_diff = np.diff(misorient_angles)
+            assert np.max(angles_diff) < 3.0
+            assert np.min(angles_diff) > -7.5
+            assert np.sum(angles_diff) < -25.0
+            # Check that recrystallization is causing faster alignment.
+            np.testing.assert_array_less(
+                misorient_angles - 3.5,  # Tolerance for GBM onset latency.
+                misorient_angles[0]
+                * np.exp(
+                    np.linspace(0, timestop, n_timesteps)
+                    * (np.cos(2 * np.deg2rad(misorient_angles[0])) - 1)
+                )
+            )
+
+            # Check alignment and texture strength (half way and final value).
+            halfway = round(n_timesteps / 2)
+            match params["gbs_threshold"]:
+                case 0:
+                    assert np.isclose(misorient_angles[halfway], 11, atol=1.5)
+                    assert np.isclose(misorient_angles[-1], 8, atol=1.25)
+                    assert np.isclose(misorient_indices[halfway], 0.975, atol=0.075)
+                    assert np.isclose(misorient_indices[-1], 0.99, atol=0.03)
+                case 0.2:
+                    assert np.isclose(misorient_angles[halfway], 13, atol=1.5)
+                    assert np.isclose(misorient_angles[-1], 11, atol=1.25)
+                    assert np.isclose(misorient_indices[halfway], 0.755, atol=0.075)
+                    assert np.isclose(misorient_indices[-1], 0.755, atol=0.075)
+                case 0.4:
+                    assert np.isclose(misorient_angles[halfway], 19, atol=1.5)
+                    assert np.isclose(misorient_angles[-1], 16, atol=1.5)
+                    assert misorient_indices[halfway] < 0.75
+                    assert misorient_indices[-1] < 0.7
+
+            # Optionally store plotting metadata.
+            if outdir is not None:
+                labels.append(f"$f_{{gbs}}$ = {params['gbs_threshold']}")
+                angles.append(misorient_angles)
+                indices.append(misorient_indices)
+
+        # Optionally plot figure.
+        if outdir is not None:
+            _vis.simple_shear_2d(
+                angles,
+                indices,
+                timestop=timestop,
+                savefile=f"{outdir}/simple_shearXZ_single_olivineA_initQ1.png",
+                markers=("o", "v", "s"),
+                labels=labels,
+                refval=45,
+            )

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -301,7 +301,7 @@ class TestSinglePolycrystalOlivineA:
                 * np.exp(
                     np.linspace(0, timestop, n_timesteps)
                     * (np.cos(2 * np.deg2rad(misorient_angles[0])) - 1)
-                )
+                ),
             )
 
             # Check alignment and texture strength (half way and final value).

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -21,9 +21,9 @@ class TestSinglePolycrystalOlivineA:
 
     def test_shearYZ_initQ1(
         self,
-        params_Kaminski2001_fig5_solid,
-        params_Kaminski2001_fig5_shortdash,
-        params_Kaminski2001_fig5_longdash,
+        params_Kaminski2001_fig5_solid,  # GBM = 0
+        params_Kaminski2001_fig5_shortdash,  # GBM = 50
+        params_Kaminski2001_fig5_longdash,  # GBM = 200
         outdir,
     ):
         """Test clockwise a-axis rotation around X.
@@ -35,7 +35,9 @@ class TestSinglePolycrystalOlivineA:
             L = 0 0 2
                 0 0 0
 
-        Similar to Fig. 5 in [Kaminski 2001]
+        Orientations set up for slip on (010)[100].
+        Tests the effect of grain boundary migration,
+        similar to Fig. 5 in [Kaminski 2001].
 
         [Kaminski 2001]: https://doi.org/10.1016%2Fs0012-821x%2801%2900356-9
 
@@ -46,7 +48,8 @@ class TestSinglePolycrystalOlivineA:
         timescale = 1 / (strain_rate_scale / 2)
         n_grains = 1000
 
-        # Initial orientations in first quadrant of YZ plane.
+        # Initial orientations with a-axis in first quadrant of the YZ plane,
+        # and c-axis along the +X direction (important!)
         # This means that the starting average is the same,
         # which is convenient for comparing the texture evolution.
         orientations_init = (
@@ -60,6 +63,10 @@ class TestSinglePolycrystalOlivineA:
             .inv()
             .as_matrix()
         )
+        # Uncomment to check a-axis vectors, should be near [0, a, a].
+        # assert False, f"{orientations_init[0:10, 0, :]}"
+        # Uncomment to check c-axis vectors, should be near [1, 0, 0].
+        # assert False, f"{orientations_init[0:10, 2, :]}"
 
         # One mineral to test each value of grain boundary mobility.
         minerals = [
@@ -83,9 +90,9 @@ class TestSinglePolycrystalOlivineA:
         for mineral, params in zip(
             minerals,
             (
-                params_Kaminski2001_fig5_solid,
-                params_Kaminski2001_fig5_shortdash,
-                params_Kaminski2001_fig5_longdash,
+                params_Kaminski2001_fig5_solid,  # GBM = 0
+                params_Kaminski2001_fig5_shortdash,  # GBM = 50
+                params_Kaminski2001_fig5_longdash,  # GBM = 200
             ),
         ):
             time = 0
@@ -159,7 +166,7 @@ class TestSinglePolycrystalOlivineA:
 
             # Optionally store plotting metadata.
             if outdir is not None:
-                labels.append(f"M* = {params['gbm_mobility']}")
+                labels.append(f"$M^∗$ = {params['gbm_mobility']}")
                 angles.append(misorient_angles)
                 indices.append(misorient_indices)
 


### PR DESCRIPTION
Adds a 2d simple shear test which varies the grain boundary sliding parameter.
This uses parameters from Kaminski 2004. Grain boundary sliding acts as an
upper bound on texture strength and a lower bound on CPO alignment.
The initial contition is set up for shear along a different axis,
but slip on the same slip system as the GBM test from https://github.com/Patol75/PyDRex/pull/38
(this tests that the model is working regardless of the orientation of the 2D shear).

![image](https://user-images.githubusercontent.com/34595875/178659362-094d7c4a-dbff-447b-a4c9-e4711037163a.png)