### PR TITLE
Finalise SCSV format

### DIFF
--- a/data/specs/spec.scsv
+++ b/data/specs/spec.scsv
@@ -3,13 +3,13 @@
 # The SCSV format is a plain text format intended for small data files.
 # A YAML header with a data schema and optional comments is added to a standard CSV file.
 # This idea was inspired by CSVY (http://csvy.org/) but does not aim to be compatible with that format.
-# A single SCSV file can store exactly one dataset.
+# A single SCSV file can store exactly one, flat dataset.
 # The file encoding must be UTF-8.
 
 # The YAML header must obey the following structure:
-schema:
+schema:  # The delimiter and missing string definitions must be enclosed in quotes, e.g. ','.
   delimiter: ','  # A single character delimiter.
-  missing: '-'  # An arbitrary-length string denoting missing data.
+  missing: '-'  # An arbitrary-length string denoting missing data (must not contain the delimiter).
   fields:  # Inline comments are supported in the YAML section.
     - name: first_column  # Column names must be valid Python identifiers as per `str.isidentifier()`.
       type: string  # Valid types are 'string', 'integer', 'float', 'boolean' or 'complex' (number).
@@ -17,7 +17,7 @@ schema:
       unit: percent  # Arbitrary, optional string describing the data units, currently not parsed.
     - name: second_column  # Type and fill value are also optional, defaults are 'string' and "".
     - name: third_column
-      type: integer  # Type of fill value must match the specified type. Use 'NaN' for floats and complex numbers.
+      type: integer  # Type of fill value must match the specified type, unless using 'NaN', see below.
       fill: 999999  # Boolean columns cannot have missing values, use a string column instead.
     - name: float_column
       type: float
@@ -26,10 +26,13 @@ schema:
       type: boolean
     - name: complex_column
       type: complex
-      fill: NaN  # Parsers should fill these with (NaN + 0j)
+      fill: NaN  # Parsers should fill these with (NaN + 0j).
 
 # The fields defined in the YAML schema must match the names in the header row of the CSV data.
 # Double quotes can be used to prevent splitting a string value that contains the delimiter.
+# The fill value for floats and complex numbers can additionaly be 'NaN',
+# which should be interpreted as the floating point NaN (e.g. numpy.nan) or as
+# the complex value with NaN for the real component and 0 for the imaginary component.
 ---
 first_column, second_column, third_column, float_column, bool_column, complex_column
 s1, A, -, 1.1, 1, 0.1

--- a/data/specs/spec.scsv
+++ b/data/specs/spec.scsv
@@ -1,0 +1,37 @@
+---
+# SCSV specification (complete example).
+# The SCSV format is a plain text format intended for small data files.
+# A YAML header with a data schema and optional comments is added to a standard CSV file.
+# This idea was inspired by CSVY (http://csvy.org/) but does not aim to be compatible with that format.
+# A single SCSV file can store exactly one dataset.
+# The file encoding must be UTF-8.
+
+# The YAML header must obey the following structure:
+schema:
+  delimiter: ','  # A single character delimiter.
+  missing: '-'  # An arbitrary-length string denoting missing data.
+  fields:  # Inline comments are supported in the YAML section.
+    - name: first_column  # Column names must be valid Python identifiers as per `str.isidentifier()`.
+      type: string  # Valid types are 'string', 'integer', 'float', 'boolean' or 'complex' (number).
+      fill: "MISSING"  # Fill value for missing data, replacement for the 'missing' string.
+      unit: percent  # Arbitrary, optional string describing the data units, currently not parsed.
+    - name: second_column  # Type and fill value are also optional, defaults are 'string' and "".
+    - name: third_column
+      type: integer  # Type of fill value must match the specified type. Use 'NaN' for floats and complex numbers.
+      fill: 999999  # Boolean columns cannot have missing values, use a string column instead.
+    - name: float_column
+      type: float
+      fill: NaN
+    - name: bool_column
+      type: boolean
+    - name: complex_column
+      type: complex
+      fill: NaN  # Parsers should fill these with (NaN + 0j)
+
+# The fields defined in the YAML schema must match the names in the header row of the CSV data.
+# Double quotes can be used to prevent splitting a string value that contains the delimiter.
+---
+first_column, second_column, third_column, float_column, bool_column, complex_column
+s1, A, -, 1.1, 1, 0.1
+-, "B, b", 10, -, False, -
+s3, -, 1, 1., true, 1+j

--- a/data/specs/spec.scsv
+++ b/data/specs/spec.scsv
@@ -29,10 +29,18 @@ schema:  # The delimiter and missing string definitions must be enclosed in quot
       fill: NaN  # Parsers should fill these with (NaN + 0j).
 
 # The fields defined in the YAML schema must match the names in the header row of the CSV data.
+
 # Double quotes can be used to prevent splitting a string value that contains the delimiter.
+
 # The fill value for floats and complex numbers can additionaly be 'NaN',
 # which should be interpreted as the floating point NaN (e.g. numpy.nan) or as
 # the complex value with NaN for the real component and 0 for the imaginary component.
+
+# The following (case-insensitive) values should be parsed as boolean True:
+# - yes
+# - true
+# - t
+# - 1
 ---
 first_column, second_column, third_column, float_column, bool_column, complex_column
 s1, A, -, 1.1, 1, 0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     numba >= 0.5
     scipy >= 1.2
     python-frontmatter
+    meshio
     vtk
 
 # ===== Optional dependencies =====

--- a/src/pydrex/io.py
+++ b/src/pydrex/io.py
@@ -12,20 +12,18 @@ the `data/` folder of the source repository. For supported cell types, see
 `SCSV_TYPEMAP`.
 
 """
-import os
 import collections as c
 import configparser
 import csv
 import functools as ft
+import os
 import pathlib
 
 import frontmatter as fm
-import numpy as np
 import meshio
-
+import numpy as np
 
 import pydrex.exceptions as _err
-
 
 SCSV_TYPEMAP = {
     "string": str,

--- a/src/pydrex/logger.py
+++ b/src/pydrex/logger.py
@@ -31,9 +31,10 @@ with _log.logfile_enable("my_log_file.log"):
 import contextlib as cl
 import functools as ft
 import logging
-import pathlib as pl
 
 import numpy as np
+
+from pydrex import io as _io
 
 np.set_printoptions(
     formatter={"float_kind": np.format_float_scientific},
@@ -75,8 +76,7 @@ LOGGER.addHandler(LOGGER_CONSOLE)
 @cl.contextmanager
 def logfile_enable(path, level=logging.DEBUG):
     """Enable logging to a file at `path` with given `level`."""
-    pl.Path(path).parent.mkdir(parents=True, exist_ok=True)
-    logger_file = logging.FileHandler(path, mode="w")
+    logger_file = logging.FileHandler(_io.resolve_path(path), mode="w")
     logger_file.setFormatter(
         logging.Formatter(
             "%(levelname)s [%(asctime)s] %(name)s: %(message)s",

--- a/src/pydrex/minerals.py
+++ b/src/pydrex/minerals.py
@@ -21,8 +21,8 @@ from scipy.spatial.transform import Rotation
 from pydrex import core as _core
 from pydrex import deformation_mechanism as _defmech
 from pydrex import exceptions as _err
-from pydrex import logger as _log
 from pydrex import io as _io
+from pydrex import logger as _log
 
 
 @unique

--- a/src/pydrex/minerals.py
+++ b/src/pydrex/minerals.py
@@ -22,6 +22,7 @@ from pydrex import core as _core
 from pydrex import deformation_mechanism as _defmech
 from pydrex import exceptions as _err
 from pydrex import logger as _log
+from pydrex import io as _io
 
 
 @unique
@@ -419,9 +420,8 @@ class Mineral:
                 "fractions": np.stack(self.fractions),
                 "orientations": np.stack(self.orientations),
             }
-            path = pl.Path(filename)
-            # Create parent directories if needed.
-            path.parent.mkdir(parents=True, exist_ok=True)
+            # Create parent directories, resolve relative paths.
+            _io.resolve_path(filename)
             # Append to file, requires postfix (unique name).
             if postfix is not None:
                 archive = ZipFile(filename, mode="a", allowZip64=True)

--- a/src/pydrex/minerals.py
+++ b/src/pydrex/minerals.py
@@ -7,7 +7,6 @@
 
 """
 import io
-import pathlib as pl
 from dataclasses import dataclass, field
 from enum import IntEnum, unique
 from zipfile import ZipFile

--- a/src/pydrex/visualisation.py
+++ b/src/pydrex/visualisation.py
@@ -98,7 +98,7 @@ def simple_shear_stationary_2d(
     if labels is not None:
         ax_mean.legend()
 
-    fig.savefig(_io.resolve_path(), bbox_inches="tight")
+    fig.savefig(_io.resolve_path(savefile), bbox_inches="tight")
 
 
 def _lag_2d_corner_flow(θ):
@@ -274,7 +274,7 @@ def corner_flow_2d(
     if labels is not None:
         ax_mean.legend()
 
-    fig.savefig(_io.resolve_path(), bbox_inches="tight")
+    fig.savefig(_io.resolve_path(savefile), bbox_inches="tight")
 
 
 def set_polefig_axis(ax, ref_axes="xz"):
@@ -371,7 +371,7 @@ def polefigures(datafile, step=1, postfix=None, savefile="polefigures.png"):
         set_polefig_axis(ax001)
         ax001.scatter(*poles(orientations, hkl=[0, 0, 1]), s=0.3, alpha=0.33, zorder=11)
 
-    fig.savefig(_io.resolve_path(), bbox_inches="tight")
+    fig.savefig(_io.resolve_path(savefile), bbox_inches="tight")
 
 
 # TODO: The contouring stuff below is mostly copied/adapted from mplstereonet, but I

--- a/src/pydrex/visualisation.py
+++ b/src/pydrex/visualisation.py
@@ -1,6 +1,5 @@
 """> PyDRex: Visualisation helpers for tests/examples."""
 import functools as ft
-import pathlib as pl
 
 import numpy as np
 from matplotlib import pyplot as plt

--- a/src/pydrex/visualisation.py
+++ b/src/pydrex/visualisation.py
@@ -7,9 +7,9 @@ from matplotlib import pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from scipy import linalg as la
 
+from pydrex import io as _io
 from pydrex import minerals as _minerals
 from pydrex import stats as _stats
-from pydrex import io as _io
 
 # Always show XY grid by default.
 plt.rcParams["axes.grid"] = True

--- a/src/pydrex/visualisation.py
+++ b/src/pydrex/visualisation.py
@@ -9,6 +9,7 @@ from scipy import linalg as la
 
 from pydrex import minerals as _minerals
 from pydrex import stats as _stats
+from pydrex import io as _io
 
 # Always show XY grid by default.
 plt.rcParams["axes.grid"] = True
@@ -41,12 +42,6 @@ def _get_marker_and_label(data, seq_index, markers, labels=None):
     if labels is not None:
         label = labels[int(seq_index / (len(data) / len(labels)))]
     return marker, label
-
-
-def _savefig_deep(fig, path):
-    """Saves a `plt.Figure` to `path`, creating necessary parent directories."""
-    pl.Path(path).parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(path, bbox_inches="tight")
 
 
 @check_marker_seq
@@ -104,7 +99,7 @@ def simple_shear_stationary_2d(
     if labels is not None:
         ax_mean.legend()
 
-    _savefig_deep(fig, savefile)
+    fig.savefig(_io.resolve_path(), bbox_inches="tight")
 
 
 def _lag_2d_corner_flow(θ):
@@ -280,7 +275,7 @@ def corner_flow_2d(
     if labels is not None:
         ax_mean.legend()
 
-    _savefig_deep(fig, savefile)
+    fig.savefig(_io.resolve_path(), bbox_inches="tight")
 
 
 def set_polefig_axis(ax, ref_axes="xz"):
@@ -377,7 +372,7 @@ def polefigures(datafile, step=1, postfix=None, savefile="polefigures.png"):
         set_polefig_axis(ax001)
         ax001.scatter(*poles(orientations, hkl=[0, 0, 1]), s=0.3, alpha=0.33, zorder=11)
 
-    _savefig_deep(fig, savefile)
+    fig.savefig(_io.resolve_path(), bbox_inches="tight")
 
 
 # TODO: The contouring stuff below is mostly copied/adapted from mplstereonet, but I

--- a/src/pydrex/vtk_helpers.py
+++ b/src/pydrex/vtk_helpers.py
@@ -11,7 +11,7 @@ def get_output(filename):
     Only supports modern vtk formats, i.e. .vtu and .pvtu files.
 
     """
-    input_path = _io._resolve_path(filename)
+    input_path = _io.resolve_path(filename)
     if input_path.suffix == ".vtu":
         reader = vtkXMLUnstructuredGridReader()
     elif input_path.suffix == ".pvtu":

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,9 +18,6 @@ If `outdir` is a directory path (string):
   (the default is `logging.DEBUG` which implies the most verbose output),
 - figures can be saved by (implementing and) calling a helper from `pydrex.visualisation`, and
 - data dumps can be saved to `outdir`, e.g. in `.npz` format (see the `Mineral.save` method)
-In all cases, saving to `outdir` should handle creation of parent directories,
-using the `pathlib` module:
-
-```
-pathlib.Path(f"{outdir}/some.file").parent.mkdir(parents=True, exist_ok=True)
-```
+In all cases, saving to `outdir` should handle creation of parent directories.
+To handle this as well as relative paths, we provide `pydrex.io.resolve_path`,
+which is a thin wrapper around some `pathlib` methods.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,8 +171,19 @@ def params_Hedjazian2017():
 
 @pytest.fixture
 def vtkfiles_2d_corner_flow():
+    # TODO: Change data fixtures to point to directories.
     datadir = pl.Path(__file__).parent / ".." / "data" / "vtu"
     return (datadir / "corner2d_2cmyr_5e5x1e5.vtu",)
+
+
+@pytest.fixture
+def scsvfiles_thirdparty():
+    return pl.Path(__file__).parent / ".." / "data" / "thirdparty"
+
+
+@pytest.fixture
+def data_specs():
+    return pl.Path(__file__).parent / ".." / "data" / "specs"
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from _pytest.logging import LoggingPlugin, _LiveLoggingStreamHandler
 from numpy import random as rn
 
 from pydrex import logger as _log
+from pydrex import io as _io
 
 matplotlib.use("Agg")  # Stop matplotlib from looking for $DISPLAY in env.
 _log.quiet_aliens()  # Stop imported modules from spamming the logs.
@@ -178,12 +179,12 @@ def vtkfiles_2d_corner_flow():
 
 @pytest.fixture
 def scsvfiles_thirdparty():
-    return pl.Path(__file__).parent / ".." / "data" / "thirdparty"
+    return _io.resolve_path(pl.Path(__file__).parent / ".." / "data" / "thirdparty")
 
 
 @pytest.fixture
 def data_specs():
-    return pl.Path(__file__).parent / ".." / "data" / "specs"
+    return _io.resolve_path(pl.Path(__file__).parent / ".." / "data" / "specs")
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,8 @@ import pytest
 from _pytest.logging import LoggingPlugin, _LiveLoggingStreamHandler
 from numpy import random as rn
 
-from pydrex import logger as _log
 from pydrex import io as _io
+from pydrex import logger as _log
 
 matplotlib.use("Agg")  # Stop matplotlib from looking for $DISPLAY in env.
 _log.quiet_aliens()  # Stop imported modules from spamming the logs.

--- a/tests/test_scsv.py
+++ b/tests/test_scsv.py
@@ -1,0 +1,260 @@
+"""> PyDRex: tests for the SCSV plain text file format."""
+import tempfile
+
+from pydrex import io as _io
+import numpy as np
+from numpy import testing as nt
+
+from pydrex import logger as _log
+
+
+def test_read_specfile(data_specs):
+    """Test SCSV spec file parsing."""
+    data = _io.read_scsv(data_specs / "spec.scsv")
+    assert data._fields == (
+        "first_column",
+        "second_column",
+        "third_column",
+        "float_column",
+        "bool_column",
+        "complex_column",
+    )
+    nt.assert_equal(data.first_column, ["s1", "MISSING", "s3"])
+    nt.assert_equal(data.second_column, ["A", "B, b", ""])
+    nt.assert_equal(data.third_column, [999999, 10, 1])
+    nt.assert_equal(data.float_column, [1.1, np.nan, 1.0])
+    nt.assert_equal(data.bool_column, [True, False, True])
+    nt.assert_equal(data.complex_column, [0.1 + 0 * 1j, np.nan + 0 * 1j, 1.0 + 1 * 1j])
+
+
+def test_save_specfile(outdir):
+    """Test SCSV spec file reproduction."""
+    schema = {
+        "delimiter": ",",
+        "missing": "-",
+        "fields": [
+            {
+                "name": "first_column",
+                "type": "string",
+                "fill": "MISSING",
+                "unit": "percent",
+            },
+            {"name": "second_column"},
+            {"name": "third_column", "type": "integer", "fill": "999999"},
+            {"name": "float_column", "type": "float", "fill": "NaN"},
+            {"name": "bool_column", "type": "boolean"},
+            {"name": "complex_column", "type": "complex", "fill": "NaN"},
+        ],
+    }
+    schema_alt = {
+        "delimiter": ",",
+        "missing": "-",
+        "fields": [
+            {
+                "name": "first_column",
+                "type": "string",
+                "unit": "percent",
+            },
+            {"name": "second_column"},
+            {"name": "third_column", "type": "integer", "fill": "999991"},
+            {"name": "float_column", "type": "float", "fill": "0.0"},
+            {"name": "bool_column", "type": "boolean"},
+            {"name": "complex_column", "type": "complex", "fill": "NaN"},
+        ],
+    }
+
+    data = [
+        ["s1", "MISSING", "s3"],
+        ["A", "B, b", ""],
+        [999999, 10, 1],
+        [1.1, np.nan, 1.0],
+        [True, False, True],
+        [0.1 + 0 * 1j, np.nan + 0 * 1j, 1.0 + 1 * 1j],
+    ]
+    data_alt = [
+        ["s1", "", "s3"],
+        ["A", "B, b", ""],
+        [999991, 10, 1],
+        [1.1, 0.0, 1.0],
+        [True, False, True],
+        [0.1 + 0 * 1j, np.nan + 0 * 1j, 1.0 + 1 * 1j],
+    ]
+
+    # The test writes two variants of the file, with identical CSV contents but
+    # different YAML header specs. Contents after thhe header must match.
+    if outdir is not None:
+        _io.save_scsv(f"{outdir}/spec_out.scsv", schema, data)
+        _io.save_scsv(f"{outdir}/spec_out_alt.scsv", schema_alt, data_alt)
+
+    temp = tempfile.NamedTemporaryFile()
+    temp_alt = tempfile.NamedTemporaryFile()
+    _io.save_scsv(temp.name, schema, data)
+    _io.save_scsv(temp_alt.name, schema_alt, data_alt)
+    raw_read = []
+    raw_read_alt = []
+    with open(temp.name) as stream:
+        raw_read = stream.readlines()[23:]  # Extra spec for first column 'fill' value.
+    with open(temp_alt.name) as stream:
+        raw_read_alt = stream.readlines()[22:]
+    _log.debug("\n  first file: %s\n  second file: %s", raw_read, raw_read_alt)
+    nt.assert_equal(raw_read, raw_read_alt)
+
+
+def test_read_Kaminski2002(scsvfiles_thirdparty):
+    data = _io.read_scsv(scsvfiles_thirdparty / "Kaminski2002_ISAtime.scsv")
+    assert data._fields == ("time_ISA", "vorticity")
+    # fmt: off
+    nt.assert_equal(
+        data.time_ISA,
+        np.array(
+            [2.48, 2.50, 2.55, 2.78, 3.07, 3.58, 4.00, 4.88, 4.01, 3.79,
+             3.72, 3.66, 3.71, 4.22, 4.73, 3.45, 1.77, 0.51]
+        ),
+    )
+    nt.assert_equal(
+        data.vorticity,
+        np.array(
+            [0.05, 0.10, 0.20, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60,
+             0.65, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95, 1.00]
+        ),
+    )
+    # fmt: on
+
+
+def test_read_Kaminski2004(scsvfiles_thirdparty):
+    data = _io.read_scsv(scsvfiles_thirdparty / "Kaminski2004_AaxisDynamicShear.scsv")
+    assert data._fields == ("time", "meanA_X0", "meanA_X02", "meanA_X04")
+    # fmt: off
+    nt.assert_equal(
+        data.time,
+        np.array(
+            [-0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9,
+             1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0,
+             2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0, 3.1,
+             3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0, 4.1, 4.2,
+             4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.0]
+        ),
+    )
+    nt.assert_equal(
+        data.meanA_X02,
+        np.array(
+            [-0.54, -0.54, -0.27, 0.13, 0.94, 2.82, 5.37, 9.53, 14.77, 20.40,
+             26.58, 32.89, 39.73, 47.25, 53.69, 58.66, 60.81, 60.81, 59.73, 58.52, 58.12,
+             56.64, 54.09, 53.69, 55.57, 57.05, 58.66, 60.54, 60.81, 61.21, 61.21, 61.61,
+             61.48, 61.61, 61.61, 61.61, 61.21, 61.21, 61.07, 60.81, 60.81, 60.54, 60.00,
+             59.60, 59.33, 58.52, 58.12, 57.85, 57.45, 57.05, 57.05]
+        ),
+    )
+    # fmt: on
+
+
+def test_read_Skemer2016(scsvfiles_thirdparty):
+    data = _io.read_scsv(scsvfiles_thirdparty / "Skemer2016_ShearStrainAngles.scsv")
+    assert data._fields == (
+        "study",
+        "sample_id",
+        "shear_strain",
+        "angle",
+        "fabric",
+        "M_index",
+    )
+    # fmt: off
+    nt.assert_equal(
+        data.study,
+        ["Z&K 1200 C", "Z&K 1200 C", "Z&K 1200 C", "Z&K 1200 C", "Z&K 1200 C",
+         "Z&K 1300 C", "Z&K 1300 C", "Z&K 1300 C", "Z&K 1300 C", "Z&K 1300 C",
+         "Z&K 1300 C", "Z&K 1300 C", "Bystricky 2000", "Bystricky 2000", "Bystricky 2000",
+         "Bystricky 2000", "Warren 2008", "Warren 2008", "Warren 2008", "Warren 2008",
+         "Warren 2008", "Warren 2008", "Warren 2008", "Warren 2008", "Warren 2008",
+         "Skemer 2011", "Skemer 2011", "Skemer 2011", "Webber 2010", "Webber 2010",
+         "Webber 2010", "Webber 2010", "Webber 2010", "Webber 2010", "Webber 2010",
+         "Katayama 2004", "Katayama 2004", "Katayama 2004", "Katayama 2004", "Katayama 2004",
+         "Katayama 2004", "Skemer 2010", "Skemer 2010", "Skemer 2010", "Skemer 2010",
+         "Skemer 2010", "Jung 2006", "Jung 2006", "Jung 2006", "Jung 2006",
+         "Jung 2006", "Jung 2006", "Hansen 2014", "Hansen 2014", "Hansen 2014",
+         "Hansen 2014", "Hansen 2014", "Hansen 2014", "Hansen 2014", "Hansen 2014",
+         "Hansen 2014", "Hansen 2014", "Hansen 2014", "Hansen 2014", "Hansen 2014",
+         "Hansen 2014", "Hansen 2014", "Hansen 2014", "Hansen 2014", "Hansen 2014",
+         "Hansen 2014", "Hansen 2014", "Hansen 2014", "Hansen 2014", "Hansen 2014",
+         "Hansen 2014", "Hansen 2014", "Hansen 2014", "H&W 2015", "H&W 2015",
+         "H&W 2015", "H&W 2015", "H&W 2015", "H&W 2015", "H&W 2015",
+         "H&W 2015", "H&W 2015", "H&W 2015", "H&W 2015", "H&W 2015",
+         "H&W 2015", "H&W 2015", "H&W 2015", "H&W 2015"],
+    )
+    nt.assert_equal(
+        data.sample_id,
+        ["PI-148", "PI-150", "PI-154", "PI-158", "PI-284", "MIT-5", "MIT-20", "MIT-6",
+         "MIT-21", "MIT-17", "MIT-18", "MIT-19", "", "", "", "", "3923J01",
+         "3923J11", "3923J13", "3923J14", "3924J06", "3924J09a", "3924J09b", "3924J08",
+         "3924J10", "PIP-20", "PIP-21", "PT-484", "", "", "", "", "", "", "", "GA10",
+         "GA38", "GA23", "GA12", "GA45", "GA25", "3925G08", "3925G05", "3925G02",
+         "3925G01", "PT-248_4", "JK43", "JK21B", "JK26", "JK11", "JK18", "JK23",
+         "PT0535", "PT0248_1", "", "PT0655", "PT0248_2", "PI-284", "PT0248_3", "PT0503_5",
+         "PT0248_4", "PT0248_5", "PT0503_4", "PT0640", "PT0503_3", "", "PT0494",
+         "PT0538", "PT0503_2", "PT0541", "PT0503_1", "PT0633", "PT0552", "PT0505",
+         "PT0651", "PT0499", "PT619", "PT0484", "3923J06", "3923J07", "3923J09",
+         "3923J08", "3923J13", "3923J12", "3924J06", "3924J05", "JP13-D07", "JP13-D06",
+         "3924J03a", "3924J03b", "3924J09a", "3924J09b", "3924J08", "3924J07"],
+    )
+    nt.assert_equal(
+        data.shear_strain,
+        np.array(
+            [
+                17, 30, 45, 65, 110, 11, 7, 65, 58, 100,
+                115, 150, 50, 200, 400, 500, 0, 65, 118, 131, 258, 386,
+                386, 525, 168, 120, 180, 350, 0, 25, 100, 130, 168, 330,
+                330, 60, 60, 80, 120, 260, 630, 60, 150, 1000, 1000, 290,
+                120, 400, 100, 110, 120, 400, 0, 30, 50, 100, 100, 110,
+                210, 270, 290, 390, 390, 400, 490, 500, 590, 680, 680, 760,
+                820, 870, 880, 1020, 1060, 1090, 1420, 1870, 32, 32, 81, 81,
+                118, 118, 258, 258, 286, 286, 337, 337, 386, 386, 525, 525
+            ]
+        ),
+    )
+    nt.assert_equal(
+        data.angle,
+        np.array(
+            [
+                43, 37, 38, 24, 20, 36, 28, 18, 10, 5,
+                10, 0, 0, 0, 0, 0, 62, 37, 49, 61, 4, 11, 0, 1, 33, 55,
+                53, 45, 55, 35, 47, 29, 37, 47, 45, -49, -26, -10, -35,
+                -10, -15, -52, -30, -14, -11, 0, 26, 15, 27, 25, 16, 36,
+                -71, -78, 71, 29, 39, 24, 12, 7.3, -3.7, -1.3, -6.1, 0.4,
+                -8.6, 5.4, 0.6, -5.5, -4.3, -8.4, -1.9, -0.9, -8.9, 2.8,
+                -2, -1.5, -4.1, -5.8, 48, 51, 44, 35, 35, 40, 1, 15, 25,
+                28, 28, 39, 1, 8, 4, 11
+            ]
+        ),
+    )
+    nt.assert_equal(
+        data.fabric,
+        [
+            "A", "A", "A", "A", "A", "A", "A", "A", "A", "A", "A", "A",
+            "D", "D", "D", "D", "A", "A", "A", "A", "A", "A", "A", "A",
+            "A", "A", "A", "A", "A", "A", "A", "A", "A", "A", "A", "E",
+            "E", "E", "E", "E", "E", "E", "E", "E", "E", "D", "A", "B",
+            "C", "C", "C", "C", "D", "D", "D", "D", "D", "D", "D", "D",
+            "D", "D", "D", "D", "D", "A", "A", "A", "A", "A", "A", "A",
+            "A", "A", "A", "A", "A", "A", "A", "A", "A", "A", "A", "A",
+            "A", "A", "A", "A", "A", "A", "A", "A", "A", "A",
+        ],
+    )
+    nt.assert_equal(
+        data.M_index,
+        np.array(
+            [
+                np.nan, np.nan, np.nan, np.nan, 0.09, np.nan, np.nan,
+                np.nan, np.nan, np.nan, np.nan, np.nan, 0.05, np.nan,
+                np.nan, 0.17, 0.08, 0.12, 0.16, 0.2, 0.17, 0.06, 0.13,
+                0.14, 0.16, np.nan, np.nan, np.nan, np.nan, np.nan,
+                np.nan, np.nan, np.nan, np.nan, np.nan, 0.17, np.nan,
+                np.nan, 0.28, np.nan, 0.44, 0.03, 0.1, 0.47, 0.37,
+                0.36, 0.06, 0.21, 0.21, 0.23, 0.27, 0.1, 0.01, 0.06,
+                0.05, 0.06, 0.06, 0.09, 0.2, 0.26, 0.36, 0.35, 0.34,
+                0.36, 0.45, 0.17, 0.4, 0.46, 0.46, 0.44, 0.35, 0.39,
+                0.4, 0.69, 0.55, 0.61, 0.51, 0.51, 0.08, 0.2, 0.16,
+                0.12, 0.12, 0.17, 0.18, 0.13, 0.15, 0.09, 0.19, 0.27,
+                0.12, 0.18, 0.14, 0.26,
+            ]
+        ),
+    )

--- a/tests/test_scsv.py
+++ b/tests/test_scsv.py
@@ -1,10 +1,10 @@
 """> PyDRex: tests for the SCSV plain text file format."""
 import tempfile
 
-from pydrex import io as _io
 import numpy as np
 from numpy import testing as nt
 
+from pydrex import io as _io
 from pydrex import logger as _log
 
 


### PR DESCRIPTION
Full SCSV I/O and tests. These files will not only be used for third party datasets but also to save pathlines from standalone runs, to complement the NPZ files which only store CPO information.