### PR TITLE
Use quaternions in postprocessing

### DIFF
--- a/src/pydrex/diagnostics.py
+++ b/src/pydrex/diagnostics.py
@@ -23,6 +23,7 @@ import scipy.special as sp
 from scipy.spatial.transform import Rotation
 
 from pydrex import stats as _st
+from pydrex import logger as _log
 
 
 def bingham_average(orientations, axis="a"):
@@ -112,6 +113,7 @@ def misorientation_index(orientations, bins=None, system=(2, 4)):
         it.combinations(Rotation.from_matrix(orientations).as_quat(), 2)
     ):
         combinations[i] = list(e)
+    _log.debug("Largest array size: %s GB", combinations.nbytes / 1e9)
 
     misorientations_data = misorientation_angles(combinations)
     θmax = _st._max_misorientation(system)

--- a/src/pydrex/diagnostics.py
+++ b/src/pydrex/diagnostics.py
@@ -19,6 +19,7 @@ import itertools as it
 
 import numpy as np
 import scipy.linalg as la
+import scipy.special as sp
 from scipy.spatial.transform import Rotation
 
 from pydrex import stats as _st
@@ -106,9 +107,13 @@ def misorientation_index(orientations, bins=None, system=(2, 4)):
 
     """
     # Compute and bin misorientation angles from orientation data.
-    misorientations_data = misorientation_angles(
-        np.array(list(it.combinations(Rotation.from_matrix(orientations).as_quat(), 2)))
-    )
+    combinations = np.empty((sp.comb(len(orientations), 2, exact=True), 2, 4))
+    for i, e in enumerate(
+        it.combinations(Rotation.from_matrix(orientations).as_quat(), 2)
+    ):
+        combinations[i] = list(e)
+
+    misorientations_data = misorientation_angles(combinations)
     θmax = _st._max_misorientation(system)
     misorientations_count, bin_edges = np.histogram(
         misorientations_data, bins=θmax, range=(0, θmax), density=True

--- a/src/pydrex/diagnostics.py
+++ b/src/pydrex/diagnostics.py
@@ -19,6 +19,7 @@ import itertools as it
 
 import numpy as np
 import scipy.linalg as la
+from scipy.spatial.transform import Rotation
 
 from pydrex import stats as _st
 
@@ -106,7 +107,7 @@ def misorientation_index(orientations, bins=None, system=(2, 4)):
     """
     # Compute and bin misorientation angles from orientation data.
     misorientations_data = misorientation_angles(
-        np.array(list(it.combinations(orientations, 2)))
+        np.array(list(it.combinations(Rotation.from_matrix(orientations).as_quat(), 2)))
     )
     θmax = _st._max_misorientation(system)
     misorientations_count, bin_edges = np.histogram(
@@ -145,30 +146,26 @@ def coaxial_index(orientations, axis1="b", axis2="a"):
 
 
 def misorientation_angles(combinations):
-    """Calculate the misorientation angles for pairs of rotation matrices.
+    """Calculate the misorientation angles for pairs of rotation quaternions.
 
     Calculate the angular distance between the rotations `combinations[:, 0]`
-    and `combinations[:, 1]`, which are expected to be 3x3 passive (alias)
-    rotation matrices.
+    and `combinations[:, 1]`, which are expected to be 1x4 passive (alias)
+    rotation quaternions.
 
-    See also <http://boris-belousov.net/2016/12/01/quat-dist/>.
+    Uses ~25% less memory than the same operation with rotation matrices.
+
+    See also:
+    - <https://math.stackexchange.com/questions/90081/quaternion-distance>
+    - <https://link.springer.com/article/10.1007/s10851-009-0161-2>
+
 
     """
-    return np.rad2deg(
+    return 2 * np.rad2deg(
         np.arccos(
-            np.clip(
-                (
-                    np.trace(
-                        combinations[:, 0]
-                        @ np.transpose(combinations[:, 1], axes=[0, 2, 1]),
-                        axis1=1,
-                        axis2=2,
-                    )
-                    - 1.0
+            np.abs(
+                np.clip(
+                    np.sum(combinations[:, 0] * combinations[:, 1], axis=1), -1.0, 1.0
                 )
-                / 2,
-                -1.0,
-                1.0,
             )
         )
     )

--- a/src/pydrex/diagnostics.py
+++ b/src/pydrex/diagnostics.py
@@ -22,8 +22,8 @@ import scipy.linalg as la
 import scipy.special as sp
 from scipy.spatial.transform import Rotation
 
-from pydrex import stats as _st
 from pydrex import logger as _log
+from pydrex import stats as _st
 
 
 def bingham_average(orientations, axis="a"):

--- a/tests/test_corner_flow_2d.py
+++ b/tests/test_corner_flow_2d.py
@@ -39,6 +39,7 @@ $$
 See also Fig. 5 in [Kaminski & Ribe, 2002](https://doi.org/10.1029/2001GC000222).
 
 """
+import time
 import contextlib as cl
 import itertools as it
 import pathlib as pl
@@ -132,6 +133,7 @@ class TestOlivineA:
             return np.reshape(velocity_gradient, (1, *velocity_gradient.shape))
 
         with optional_logging:
+            _begin = time.perf_counter()
             for z_exit in z_ends:
                 mineral = _minerals.Mineral(
                     _minerals.MineralPhase.olivine,
@@ -203,6 +205,10 @@ class TestOlivineA:
                         orientations_resampled
                     )
                     bingham_vectors[idx] = direction_mean
+
+                _log.debug(
+                    "Total walltime: %s minutes", (time.perf_counter() - _begin) / 60
+                )
 
                 if outdir is not None:
                     mineral.save(npzpath, postfix=stringify(z_exit))

--- a/tests/test_corner_flow_2d.py
+++ b/tests/test_corner_flow_2d.py
@@ -39,10 +39,10 @@ $$
 See also Fig. 5 in [Kaminski & Ribe, 2002](https://doi.org/10.1029/2001GC000222).
 
 """
-import time
 import contextlib as cl
 import itertools as it
 import pathlib as pl
+import time
 
 import numba as nb
 import numpy as np


### PR DESCRIPTION
Progress towards #88 (reduces peak mem usage by a bit over half). I think this approach is better than implementing an iterator, which causes a significant (3x minimum) CPU time increase even with mutliprocessing. The other method can be added later if needed.

For 20,000 grains, the routines now need to allocate just under 300GB. This is feasible on normalsr NCI queues (memory-rich HPC queues), and more grains than that doesn't make sense even for testing.

For 10,000 grains, which is the absolute maximum of what I would consider "normal use", we need to allocate just under 75GB. This is not too bad, maybe even some smaller clusters can do it.

I should probably document the memory requirements somewhere eventually. But a bonus of preallocating the array is that any simulations will now fail quite early if they don't find the necessary amount of memory available. Performance cost of converting to quaternions is not that much, about 1% difference for the 2d cornerflow test, see runtime heatmaps below. They don't show total runtime so here it is for 2000 grains:

(left) With DCM matrices: 7.017 minutes, 39.26% spent in `misorientation_index`
(right) With Quaternions: 7.064 minutes, 39.67% spent in `misorientation_index`

<img src="https://user-images.githubusercontent.com/34595875/232510700-d4b48093-8d11-4462-a938-bba673aeda8c.png" width="49%" /> <img src="https://user-images.githubusercontent.com/34595875/232510906-ad6af64d-b509-4161-98f0-d88ea78f921a.png" width="49%" />