### PR TITLE
feat: Expose mode setting of logfile

### DIFF
--- a/src/pydrex/logger.py
+++ b/src/pydrex/logger.py
@@ -74,9 +74,9 @@ LOGGER.addHandler(LOGGER_CONSOLE)
 
 
 @cl.contextmanager
-def logfile_enable(path, level=logging.DEBUG):
+def logfile_enable(path, level=logging.DEBUG, mode="w"):
     """Enable logging to a file at `path` with given `level`."""
-    logger_file = logging.FileHandler(_io.resolve_path(path), mode="w")
+    logger_file = logging.FileHandler(_io.resolve_path(path), mode=mode)
     logger_file.setFormatter(
         logging.Formatter(
             "%(levelname)s [%(asctime)s] %(name)s: %(message)s",


### PR DESCRIPTION
For fluidity models I need to write to the log file in append mode, because I call `enable_logfile` at each simulation step.