### PR TITLE
feat: Add error logging to SCSV validation

### DIFF
--- a/src/pydrex/exceptions.py
+++ b/src/pydrex/exceptions.py
@@ -40,5 +40,4 @@ class SCSVError(Error):
     """
 
     def __init__(self, message):  # pylint: disable=super-init-not-called
-        # TODO: Add line number?
         self.message = message


### PR DESCRIPTION
While trying to read an old SCSV pathline file, I found that the generic error message by itself is not very helpful. This adds log messages when the SCSV schema of a file/dataset cannot be validated which describe the reason for failure.

![scsv_logging](https://github.com/Patol75/PyDRex/assets/34595875/e0da5497-31b5-4bf3-8c0c-00c366362d4f)
