### PR TITLE
Add core OPX tests

### DIFF
--- a/src/pydrex/core.py
+++ b/src/pydrex/core.py
@@ -65,7 +65,7 @@ def get_crss(phase, fabric):
 
     Returns an array of the normalised threshold stresses required to activate slip on
     each slip system. Olivine slip systems are ordered according to the convention used
-    for `OLIVINE_SLIP_SYSTEMS`.
+    for `pydrex.minerals.OLIVINE_SLIP_SYSTEMS`.
 
     """
     if phase == MineralPhase.olivine:
@@ -109,9 +109,8 @@ def derivatives(
     """Get derivatives of orientation and volume distribution.
 
     Args:
-    - `phase` (int) — ordinal number of the mineral phase
-                      see `pydrex.minerals.MineralPhase`
-    - `fabric` (int) — ordinal number of the fabric type, see `pydrex.fabric`
+    - `phase` (`MineralPhase`) — ordinal number of the mineral phase
+    - `fabric` (`MineralFabric`) — ordinal number of the fabric type
     - `n_grains` (int) — number of "grains" i.e. discrete volume segments
     - `orientations` (array) — `n_grains`x3x3 orientations (direction cosines)
     - `fractions` (array) — volume fractions of the "grains" relative to aggregate volume
@@ -123,7 +122,6 @@ def derivatives(
     - `gmb_mobility` (float) — grain boundary mobility parameter
     - `volume_fraction` (float) — volume fraction of the mineral phase relative to
                                   other phases
-    .. warning:: Raises zero-division errors if the vorticity is zero.
 
     Returns a tuple with the rotation rates and grain volume fraction changes.
 
@@ -160,8 +158,7 @@ def _get_deformation_rate(phase, orientation, slip_rates):
     defined by the principal strain axes (finite strain ellipsoid).
 
     Args:
-    - `phase` (int) — ordinal number of the mineral phase
-                      see `pydrex.minerals.MineralPhase`
+    - `phase` (`MineralPhase`) — ordinal number of the mineral phase
     - `orientation` (array) — 3x3 orientation matrix (direction cosines)
     - `slip_rates` (array) — slip rates relative to slip rate on softest slip system
 
@@ -401,9 +398,8 @@ def _get_rotation_and_strain(
     """Get the crystal axes rotation rate and strain energy of individual grain.
 
     Args:
-    - `phase` (int) — ordinal number of the mineral phase
-                      see `pydrex.minerals.MineralPhase`
-    - `fabric` (int) — ordinal number of the fabric type, see `pydrex.fabric`
+    - `phase` (`MineralPhase`) — ordinal number of the mineral phase
+    - `fabric` (`MineralFabric`) — ordinal number of the fabric type
     - `orientation` (array) — 3x3 orientation matrix (direction cosines)
     - `strain_rate` (array) — 3x3 dimensionless strain rate matrix
     - `velocity_gradient` (array) — 3x3 dimensionless velocity gradient matrix
@@ -412,8 +408,6 @@ def _get_rotation_and_strain(
     - `nucleation_efficiency (float) — parameter controlling grain nucleation
 
     Note that "new" grains are assumed to rotate with their parent.
-
-    .. warning:: Raises zero-division errors if the vorticity is zero.
 
     Returns a tuple with the rotation rate of the crystalline axes
     with respect to the principal strain axes and strain energy of the grain.

--- a/src/pydrex/core.py
+++ b/src/pydrex/core.py
@@ -179,7 +179,7 @@ def _get_deformation_rate(phase, orientation, slip_rates):
             elif phase == MineralPhase.enstatite:
                 deformation_rate[i, j] = 2 * orientation[2, i] * orientation[0, j]
             else:
-                raise SystemExit(1)  # Should never happen.
+                assert False  # Should never happen.
     return deformation_rate
 
 
@@ -425,7 +425,7 @@ def _get_rotation_and_strain(
         slip_indices = np.argsort(1 / crss)
         slip_rates = np.repeat(np.nan, 4)
     else:
-        raise SystemExit(1)  # Should never happen.
+        assert False  # Should never happen.
 
     deformation_rate = _get_deformation_rate(phase, orientation, slip_rates)
     slip_rate_softest = _get_slip_rate_softest(deformation_rate, velocity_gradient)
@@ -455,5 +455,5 @@ def _get_rotation_and_strain(
             nucleation_efficiency,
         )
     else:
-        raise SystemExit(1)  # Should never happen.
+        assert False  # Should never happen.
     return orientation_change, strain_energy

--- a/src/pydrex/core.py
+++ b/src/pydrex/core.py
@@ -24,6 +24,7 @@ PERMUTATION_SYMBOL = np.array(
 @unique
 class MineralPhase(IntEnum):
     """Supported mineral phases."""
+
     olivine = 0
     enstatite = 1
 
@@ -31,6 +32,7 @@ class MineralPhase(IntEnum):
 @unique
 class DeformationRegime(IntEnum):
     """Deformation mechanism regimes."""
+
     diffusion = 0
     dislocation = 1
     byerlee = 2
@@ -48,6 +50,7 @@ class MineralFabric(IntEnum):
       [Bernard et al., 2021](https://doi.org/10.1016/j.tecto.2021.228954).
 
     """
+
     olivine_A = 0
     olivine_B = 1
     olivine_C = 2
@@ -292,9 +295,7 @@ def _get_orientation_change(
             for r in range(3):
                 for s in range(3):
                     orientation_change[p, q] += (
-                        PERMUTATION_SYMBOL[q, r, s]
-                        * orientation[p, s]
-                        * spin_vector[r]
+                        PERMUTATION_SYMBOL[q, r, s] * orientation[p, s] * spin_vector[r]
                     )
 
     return orientation_change

--- a/src/pydrex/core.py
+++ b/src/pydrex/core.py
@@ -1,6 +1,6 @@
-r"""> PyDRex: Core D-ReX functions and enums.
+r"""> PyDRex: Core D-Rex functions and enums.
 
-The function `derivatives` implements the core DRex solver, which computes the
+The function `derivatives` implements the core D-Rex solver, which computes the
 crystallographic rotation rate and changes in fractional grain volumes.
 
 """
@@ -179,7 +179,7 @@ def _get_deformation_rate(phase, orientation, slip_rates):
             elif phase == MineralPhase.enstatite:
                 deformation_rate[i, j] = 2 * orientation[2, i] * orientation[0, j]
             else:
-                assert False  # Should never happen.
+                raise SystemExit(1)  # Should never happen.
     return deformation_rate
 
 
@@ -425,7 +425,7 @@ def _get_rotation_and_strain(
         slip_indices = np.argsort(1 / crss)
         slip_rates = np.repeat(np.nan, 4)
     else:
-        assert False  # Should never happen.
+        raise SystemExit(1)  # Should never happen.
 
     deformation_rate = _get_deformation_rate(phase, orientation, slip_rates)
     slip_rate_softest = _get_slip_rate_softest(deformation_rate, velocity_gradient)
@@ -455,5 +455,5 @@ def _get_rotation_and_strain(
             nucleation_efficiency,
         )
     else:
-        assert False  # Should never happen.
+        raise SystemExit(1)  # Should never happen.
     return orientation_change, strain_energy

--- a/src/pydrex/logger.py
+++ b/src/pydrex/logger.py
@@ -74,6 +74,23 @@ LOGGER.addHandler(LOGGER_CONSOLE)
 
 
 @cl.contextmanager
+def handler_level(level, handler=LOGGER_CONSOLE):
+    """Set logging handler level for current context.
+
+    Args:
+    - `level` (string) — logging level name e.g. "DEBUG", "ERROR", etc.
+      See Python's logging module for details.
+    - `handler` (optional, `logging.Handler`) — alternative handler to control instead
+      of the default, `LOGGER_CONSOLE`.
+
+    """
+    default_level = handler.level
+    handler.setLevel(level)
+    yield
+    handler.setLevel(default_level)
+
+
+@cl.contextmanager
 def logfile_enable(path, level=logging.DEBUG, mode="w"):
     """Enable logging to a file at `path` with given `level`."""
     logger_file = logging.FileHandler(_io.resolve_path(path), mode=mode)

--- a/src/pydrex/minerals.py
+++ b/src/pydrex/minerals.py
@@ -311,7 +311,7 @@ class Mineral:
         elif self.phase == _core.MineralPhase.enstatite:
             volume_fraction = config["enstatite_fraction"]
         else:
-            assert False  # Should never happen.
+            raise SystemExit(1)  # Should never happen.
 
         y_start = np.hstack(
             (

--- a/src/pydrex/minerals.py
+++ b/src/pydrex/minerals.py
@@ -21,7 +21,6 @@ from pydrex import exceptions as _err
 from pydrex import io as _io
 from pydrex import logger as _log
 
-
 OLIVINE_STIFFNESS = np.array(
     [
         [320.71, 69.84, 71.22, 0.0, 0.0, 0.0],

--- a/src/pydrex/minerals.py
+++ b/src/pydrex/minerals.py
@@ -311,7 +311,7 @@ class Mineral:
         elif self.phase == _core.MineralPhase.enstatite:
             volume_fraction = config["enstatite_fraction"]
         else:
-            raise SystemExit(1)  # Should never happen.
+            assert False  # Should never happen.
 
         y_start = np.hstack(
             (

--- a/src/pydrex/mock.py
+++ b/src/pydrex/mock.py
@@ -1,10 +1,10 @@
 """> PyDRex: Mock objects for testing and reproducibility."""
-from pydrex.minerals import OlivineFabric
+from pydrex.core import MineralFabric
 
 PARAMS_FRATERS2021 = {
     "olivine_fraction": 0.7,
     "enstatite_fraction": 0.3,
-    "initial_olivine_fabric": OlivineFabric.A,
+    "initial_olivine_fabric": MineralFabric.olivine_A,
     "stress_exponent": 1.5,
     "deformation_exponent": 3.5,
     "gbm_mobility": 125,
@@ -17,7 +17,7 @@ PARAMS_FRATERS2021 = {
 PARAMS_KAMINSKI2001_FIG5_SOLID = {
     "olivine_fraction": 1,
     "enstatite_fraction": 0,
-    "initial_olivine_fabric": OlivineFabric.A,
+    "initial_olivine_fabric": MineralFabric.olivine_A,
     "stress_exponent": 1.5,
     "deformation_exponent": 3.5,
     "gbm_mobility": 0,
@@ -30,7 +30,7 @@ PARAMS_KAMINSKI2001_FIG5_SOLID = {
 PARAMS_KAMINSKI2001_FIG5_SHORTDASH = {
     "olivine_fraction": 1,
     "enstatite_fraction": 0,
-    "initial_olivine_fabric": OlivineFabric.A,
+    "initial_olivine_fabric": MineralFabric.olivine_A,
     "stress_exponent": 1.5,
     "deformation_exponent": 3.5,
     "gbm_mobility": 50,
@@ -43,7 +43,7 @@ PARAMS_KAMINSKI2001_FIG5_SHORTDASH = {
 PARAMS_KAMINSKI2001_FIG5_LONGDASH = {
     "olivine_fraction": 1,
     "enstatite_fraction": 0,
-    "initial_olivine_fabric": OlivineFabric.A,
+    "initial_olivine_fabric": MineralFabric.olivine_A,
     "stress_exponent": 1.5,
     "deformation_exponent": 3.5,
     "gbm_mobility": 200,
@@ -56,7 +56,7 @@ PARAMS_KAMINSKI2001_FIG5_LONGDASH = {
 PARAMS_KAMINSKI2004_FIG4_TRIANGLES = {
     "olivine_fraction": 1,
     "enstatite_fraction": 0,
-    "initial_olivine_fabric": OlivineFabric.A,
+    "initial_olivine_fabric": MineralFabric.olivine_A,
     "stress_exponent": 1.5,
     "deformation_exponent": 3.5,
     "gbm_mobility": 125,
@@ -69,7 +69,7 @@ PARAMS_KAMINSKI2004_FIG4_TRIANGLES = {
 PARAMS_KAMINSKI2004_FIG4_SQUARES = {
     "olivine_fraction": 1,
     "enstatite_fraction": 0,
-    "initial_olivine_fabric": OlivineFabric.A,
+    "initial_olivine_fabric": MineralFabric.olivine_A,
     "stress_exponent": 1.5,
     "deformation_exponent": 3.5,
     "gbm_mobility": 125,
@@ -82,7 +82,7 @@ PARAMS_KAMINSKI2004_FIG4_SQUARES = {
 PARAMS_KAMINSKI2004_FIG4_CIRCLES = {
     "olivine_fraction": 1,
     "enstatite_fraction": 0,
-    "initial_olivine_fabric": OlivineFabric.A,
+    "initial_olivine_fabric": MineralFabric.olivine_A,
     "stress_exponent": 1.5,
     "deformation_exponent": 3.5,
     "gbm_mobility": 125,
@@ -95,7 +95,7 @@ PARAMS_KAMINSKI2004_FIG4_CIRCLES = {
 PARAMS_HEDJAZIAN2017 = {
     "olivine_fraction": 0.7,
     "enstatite_fraction": 0.3,
-    "initial_olivine_fabric": OlivineFabric.A,
+    "initial_olivine_fabric": MineralFabric.olivine_A,
     "stress_exponent": 1.5,
     "deformation_exponent": 3.5,
     "gbm_mobility": 10,

--- a/src/pydrex/stats.py
+++ b/src/pydrex/stats.py
@@ -161,7 +161,7 @@ def misorientations_random(low, high, system=(2, 4)):
                 )
             )
         else:
-            assert False  # Should never happen.
+            raise SystemExit(1)  # Should never happen.
 
     return np.sum(counts_both) / 2
 

--- a/src/pydrex/stats.py
+++ b/src/pydrex/stats.py
@@ -161,7 +161,7 @@ def misorientations_random(low, high, system=(2, 4)):
                 )
             )
         else:
-            raise SystemExit(1)  # Should never happen.
+            assert False  # Should never happen.
 
     return np.sum(counts_both) / 2
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,7 @@ def pytest_configure(config):
         handler = _LiveLoggingStreamHandler(terminal_reporter, capture_manager)
         handler.setFormatter(_log.LOGGER_CONSOLE.formatter)
         handler.setLevel(_log.LOGGER_CONSOLE.level)
+        _log.LOGGER_PYTEST = handler
         config.pluginmanager.register(
             PytestConsoleLogger(config), PytestConsoleLogger.name
         )
@@ -61,6 +62,13 @@ def pytest_addoption(parser):
 @pytest.fixture(scope="session")
 def outdir(request):
     return request.config.getoption("--outdir")
+
+
+@pytest.fixture(scope="function")
+def console_handler(request):
+    return request.config.pluginmanager.get_plugin(
+        "pytest-console-logger"
+    ).log_cli_handler
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,9 +66,11 @@ def outdir(request):
 
 @pytest.fixture(scope="function")
 def console_handler(request):
-    return request.config.pluginmanager.get_plugin(
-        "pytest-console-logger"
-    ).log_cli_handler
+    if request.config.option.verbose > 0:
+        return request.config.pluginmanager.get_plugin(
+            "pytest-console-logger"
+        ).log_cli_handler
+    return _log.LOGGER_CONSOLE
 
 
 @pytest.fixture

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -74,7 +74,7 @@ class TestSimpleShearOPX:
                     orientations=Rotation.from_rotvec([[0, 0, θ]]).as_matrix(),
                     fractions=np.array([1.0]),
                     strain_rate=np.array([[0, 1, 0], [1, 0, 0], [0, 0, 0]]),
-                    velocity_gradient=np.array([[0, 2, 0], [2, 0, 0], [0, 0, 0]]),
+                    velocity_gradient=np.array([[0, 0, 0], [2, 0, 0], [0, 0, 0]]),
                     stress_exponent=1.5,
                     deformation_exponent=3.5,
                     nucleation_efficiency=5,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -47,7 +47,7 @@ class TestSimpleShearOPX:
                 sinθ = np.sin(θ)
                 target_orientations_diff = np.array(
                     [
-                        [sinθ * (1 + cos2θ), 0, - cosθ * (1 + cos2θ)],
+                        [sinθ * (1 + cos2θ), 0, -cosθ * (1 + cos2θ)],
                         [0, 0, 0],
                         [cosθ * (1 + cos2θ), 0, sinθ * (1 + cos2θ)],
                     ]

--- a/tests/test_corner_flow_2d.py
+++ b/tests/test_corner_flow_2d.py
@@ -49,6 +49,7 @@ import numpy as np
 from numpy import testing as nt
 from scipy.spatial.transform import Rotation
 
+from pydrex import core as _core
 from pydrex import deformation_mechanism as _defmech
 from pydrex import diagnostics as _diagnostics
 from pydrex import io as _io
@@ -133,8 +134,8 @@ class TestOlivineA:
             _begin = time.perf_counter()
             for z_exit in z_ends:
                 mineral = _minerals.Mineral(
-                    _minerals.MineralPhase.olivine,
-                    _minerals.OlivineFabric.A,
+                    _core.MineralPhase.olivine,
+                    _core.MineralFabric.olivine_A,
                     _defmech.Regime.dislocation,
                     n_grains=n_grains,
                     fractions_init=np.full(n_grains, 1 / n_grains),

--- a/tests/test_scsv.py
+++ b/tests/test_scsv.py
@@ -10,7 +10,7 @@ from pydrex import io as _io
 from pydrex import logger as _log
 
 
-def test_validate_schema():
+def test_validate_schema(console_handler):
     """Test SCSV schema validation."""
     schema_nofill = {
         "delimiter": ",",
@@ -43,28 +43,29 @@ def test_validate_schema():
         "fields": [{"name": "baddelim", "type": "float", "fill": "NaN"}],
     }
 
-    with pytest.raises(_err.SCSVError):
-        temp = tempfile.NamedTemporaryFile()
-        _io.save_scsv(temp.name, schema_nofill, [[0.1]])
-    with pytest.raises(_err.SCSVError):
-        temp = tempfile.NamedTemporaryFile()
-        _io.save_scsv(temp.name, schema_nomissing, [[0.1]])
-    with pytest.raises(_err.SCSVError):
-        temp = tempfile.NamedTemporaryFile()
-        _io.save_scsv(temp.name, schema_nofields, [[0.1]])
-    with pytest.raises(_err.SCSVError):
-        temp = tempfile.NamedTemporaryFile()
-        _io.save_scsv(temp.name, schema_badfieldname, [[0.1]])
-    with pytest.raises(_err.SCSVError):
-        temp = tempfile.NamedTemporaryFile()
-        _io.save_scsv(temp.name, schema_delimiter_eq_missing, [[0.1]])
-    with pytest.raises(_err.SCSVError):
-        temp = tempfile.NamedTemporaryFile()
-        _io.save_scsv(temp.name, schema_delimiter_in_missing, [[0.1]])
-    # CSV module already raises a TypeError on long delimiters.
-    with pytest.raises(TypeError):
-        temp = tempfile.NamedTemporaryFile()
-        _io.save_scsv(temp.name, schema_long_delimiter, [[0.1]])
+    with _log.handler_level("CRITICAL", console_handler):
+        with pytest.raises(_err.SCSVError):
+            temp = tempfile.NamedTemporaryFile()
+            _io.save_scsv(temp.name, schema_nofill, [[0.1]])
+        with pytest.raises(_err.SCSVError):
+            temp = tempfile.NamedTemporaryFile()
+            _io.save_scsv(temp.name, schema_nomissing, [[0.1]])
+        with pytest.raises(_err.SCSVError):
+            temp = tempfile.NamedTemporaryFile()
+            _io.save_scsv(temp.name, schema_nofields, [[0.1]])
+        with pytest.raises(_err.SCSVError):
+            temp = tempfile.NamedTemporaryFile()
+            _io.save_scsv(temp.name, schema_badfieldname, [[0.1]])
+        with pytest.raises(_err.SCSVError):
+            temp = tempfile.NamedTemporaryFile()
+            _io.save_scsv(temp.name, schema_delimiter_eq_missing, [[0.1]])
+        with pytest.raises(_err.SCSVError):
+            temp = tempfile.NamedTemporaryFile()
+            _io.save_scsv(temp.name, schema_delimiter_in_missing, [[0.1]])
+        # CSV module already raises a TypeError on long delimiters.
+        with pytest.raises(TypeError):
+            temp = tempfile.NamedTemporaryFile()
+            _io.save_scsv(temp.name, schema_long_delimiter, [[0.1]])
 
 
 def test_read_specfile():

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -12,11 +12,11 @@ import contextlib as cl
 import numpy as np
 from scipy.spatial.transform import Rotation
 
+from pydrex import core as _core
 from pydrex import deformation_mechanism as _defmech
 from pydrex import diagnostics as _diagnostics
 from pydrex import logger as _log
 from pydrex import minerals as _minerals
-from pydrex import core as _core
 from pydrex import stats as _stats
 from pydrex import visualisation as _vis
 

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -189,7 +189,6 @@ class TestSinglePolycrystalOlivineA:
                 savefile=f"{outdir}/simple_shearYZ_stationary_olivineA_initQ1.png",
                 markers=("o", "v", "s"),
                 labels=labels,
-                refval=45,
             )
 
     def test_shearXZ_initQ1(
@@ -355,5 +354,4 @@ class TestSinglePolycrystalOlivineA:
                 savefile=f"{outdir}/simple_shearXZ_stationary_olivineA_initQ1.png",
                 markers=("o", "v", "s"),
                 labels=labels,
-                refval=45,
             )

--- a/tests/test_simple_shear_2d.py
+++ b/tests/test_simple_shear_2d.py
@@ -16,6 +16,7 @@ from pydrex import deformation_mechanism as _defmech
 from pydrex import diagnostics as _diagnostics
 from pydrex import logger as _log
 from pydrex import minerals as _minerals
+from pydrex import core as _core
 from pydrex import stats as _stats
 from pydrex import visualisation as _vis
 
@@ -79,8 +80,8 @@ class TestSinglePolycrystalOlivineA:
         # One mineral to test each value of grain boundary mobility.
         minerals = [
             _minerals.Mineral(
-                _minerals.MineralPhase.olivine,
-                _minerals.OlivineFabric.A,
+                _core.MineralPhase.olivine,
+                _core.MineralFabric.olivine_A,
                 _defmech.Regime.dislocation,
                 n_grains=n_grains,
                 fractions_init=np.full(n_grains, 1 / n_grains),
@@ -240,8 +241,8 @@ class TestSinglePolycrystalOlivineA:
         # One mineral to test each grain boundary sliding threshold.
         minerals = [
             _minerals.Mineral(
-                _minerals.MineralPhase.olivine,
-                _minerals.OlivineFabric.A,
+                _core.MineralPhase.olivine,
+                _core.MineralFabric.olivine_A,
                 _defmech.Regime.dislocation,
                 n_grains=n_grains,
                 fractions_init=np.full(n_grains, 1 / n_grains),

--- a/tools/h5part_reader.py
+++ b/tools/h5part_reader.py
@@ -17,6 +17,7 @@ from zipfile import ZipFile
 import h5py
 import numpy as np
 
+from pydrex import core as _core
 from pydrex import minerals as _minerals
 
 
@@ -75,8 +76,8 @@ if __name__ == "__main__":
 
         for particle_id in file["Step#0/id"][:]:
             option_map = {
-                "olivine": _minerals.MineralPhase.olivine,
-                "enstatite": _minerals.MineralPhase.enstatite,
+                "olivine": _core.MineralPhase.olivine,
+                "enstatite": _core.MineralPhase.enstatite,
                 "A": _minerals.OlivineFabric.A,
                 "B": _minerals.OlivineFabric.B,
                 "C": _minerals.OlivineFabric.C,


### PR DESCRIPTION
Adds some enstatite tests to catch a Numba typing issue when multiphase minerals were used, and refactors some symbols to avoid the crash.

This refactoring avoids the need for explicit numba type signatures which led to more numba errors for other tests.