### PR TITLE
feat: Add command line polefigure plotting tool.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ repository = "https://github.com/Patol75/PyDRex/"
 documentation = "https://patol75.github.io/PyDRex/"
 
 [project.scripts]
-pydrex = "pydrex.run:main"
+pydrex-polefigures = "pydrex.cli:CLI_HANDLERS.pole_figure_visualiser"
 
 # Make setuptools include datafiles in wheels/packages.
 # Data files must be inside the package directory.

--- a/src/pydrex/cli.py
+++ b/src/pydrex/cli.py
@@ -1,16 +1,16 @@
 """PyDRex: Entry points for command line tools."""
-import os
 import argparse
+import os
 from collections import namedtuple
 from dataclasses import dataclass
 
 import numpy as np
 
+from pydrex import exceptions as _err
+from pydrex import logger as _log
 from pydrex import minerals as _minerals
 from pydrex import stats as _stats
-from pydrex import logger as _log
 from pydrex import visualisation as _vis
-from pydrex import exceptions as _err
 
 # NOTE: Register all cli handlers in the namedtuple at the end of the file.
 
@@ -47,9 +47,9 @@ class PoleFigureVisualiser:
                     i_range = range(0, 25)
 
             orientations_resampled = [
-                _stats.resample_orientations(mineral.orientations[i], mineral.fractions[i])[
-                    0
-                ]
+                _stats.resample_orientations(
+                    mineral.orientations[i], mineral.fractions[i]
+                )[0]
                 for i in np.arange(i_range.start, i_range.stop, i_range.step, dtype=int)
             ]
             _vis.polefigures(


### PR DESCRIPTION
Makes it easy to run `pydrex-polefigure` from the command line to plot pole figures of a serialized pydrex output (.npz file). The thing has it's own `--help` and all that stuff.

Also fixes a typo bug that appeared `visualisation.polefigures`.