### PR TITLE
fix: Fix unbound custom_points local in mesh generator

### DIFF
--- a/src/pydrex/cli.py
+++ b/src/pydrex/cli.py
@@ -55,6 +55,7 @@ class MeshGenerator(CliTool):
             center = [float(s) for s in args.center.split(",")]
             assert len(center) == 2
 
+        custom_points = None
         if args.custom_points is not None:
             _custom_points = [
                 [*map(float, point.split(":"))]


### PR DESCRIPTION
Fixes error from unbound `custom_points` used in L100 of `cli.py`. The variable should be initialised to `None` before passing CLI arguments in case custom points are not supplied on the command line.