### PR TITLE
dev: Ensure latest setuptools used in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13']
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libglu1-mesa
           sudo apt-get install -y python3-pip
-          python3 -m pip install --upgrade pip setuptools
+          python3 -m pip install --upgrade pip
           python3 -m pip install "$PWD[test]"
           python3 -m pytest -rN
 
@@ -39,11 +39,11 @@ jobs:
     runs-on: macos-15-intel
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13']
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install and test
         run: |
-          python3 -m pip install --upgrade pip setuptools
+          python3 -m pip install --upgrade pip
           python3 -m pip install "$PWD[test]"
           python3 -m pytest -rN
 
@@ -61,11 +61,11 @@ jobs:
     runs-on: windows-2025
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13']
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -74,6 +74,6 @@ jobs:
 
       - name: Install and test
         run: |
-          python3 -m pip install --upgrade pip setuptools
+          python3 -m pip install --upgrade pip
           python3 -m pip install "$PWD[test]"
           python3 -m pytest -rN

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libglu1-mesa
           sudo apt-get install -y python3-pip
-          python3 -m pip install --upgrade pip
+          python3 -m pip install --upgrade pip setuptools
           python3 -m pip install "$PWD[test]"
           python3 -m pytest -rN
 
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install and test
         run: |
-          python3 -m pip install --upgrade pip
+          python3 -m pip install --upgrade pip setuptools
           python3 -m pip install "$PWD[test]"
           python3 -m pytest -rN
 
@@ -74,6 +74,6 @@ jobs:
 
       - name: Install and test
         run: |
-          python3 -m pip install --upgrade pip
+          python3 -m pip install --upgrade pip setuptools
           python3 -m pip install "$PWD[test]"
           python3 -m pytest -rN

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,8 @@ jobs:
       - name: Install and test
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install --no-build-isolation "setuptools<81"
+          python3 -m pip install --force-reinstall "setuptools<81"
+          python3 -m pip install --no-build-isolation llvmlite
           python3 -m pip install "$PWD[test]"
           python3 -m pytest -rN
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
   install-macos:
     name: (MacOS) Install package and run tests
-    runs-on: macos-15-intel
+    runs-on: macos-26-intel
     strategy:
       matrix:
         python-version: ['3.12', '3.13']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Install and test
         run: |
           python3 -m pip install --upgrade pip
+          python3 -m pip install --no-build-isolation "setuptools<81"
           python3 -m pip install "$PWD[test]"
           python3 -m pytest -rN
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,12 +21,12 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Setup Just
         uses: extractions/setup-just@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,11 +28,11 @@ repos:
     -   id: mixed-line-ending
     -   id: trailing-whitespace
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.1
+    rev: v0.15.7
     hooks:
     -   id: ruff
         types_or: [ python, pyi, jupyter ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,8 @@
 # Use modern (PEP621, PEP660) setuptools build system.
 # PEP 660 editable installs: <https://github.com/pypa/setuptools/blob/main/NEWS.rst#v6400>.
 [build-system]
-requires = ["setuptools>=80", "setuptools_scm>=8"]
+requires = ["setuptools>=80", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
-
-# Automatically use the version number from vcs (e.g. git) tags,
-# <https://github.com/pypa/setuptools_scm>.
-[tool.setuptools_scm]
 
 # Docs: <https://packaging.python.org/en/latest/specifications/pyproject-toml/>.
 [project]
@@ -14,7 +10,7 @@ name = "pydrex"
 dynamic = ["version"]  # Managed by setuptools_scm.
 description = "Dynamic CPO calculations for olivine-enstatite polycrystal aggregates"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = {file = "LICENSE"}
 authors = [
     {name = "Thomas Duvernay", email = "td75013@hotmail.fr"},

--- a/tools/venv_install.sh
+++ b/tools/venv_install.sh
@@ -26,7 +26,7 @@ warn() { >&2 printf '%s\n' "$SCRIPTNAME: $1"; }
 upgrade() {
     . .venv-"${PWD##*/}"/bin/activate
     [ -f requirements.txt ] && mv -i requirements.txt requirements.bak
-    pip install --upgrade pip pip-tools && pip-compile --resolver=backtracking && pip-sync
+    pip install --upgrade pip pip-tools setuptools && pip-compile --resolver=backtracking && pip-sync
     pip install -e "${PWD}[dev,lsp,doc,test]"
 }
 

--- a/tools/venv_install.sh
+++ b/tools/venv_install.sh
@@ -26,7 +26,7 @@ warn() { >&2 printf '%s\n' "$SCRIPTNAME: $1"; }
 upgrade() {
     . .venv-"${PWD##*/}"/bin/activate
     [ -f requirements.txt ] && mv -i requirements.txt requirements.bak
-    pip install --upgrade pip pip-tools setuptools && pip-compile --resolver=backtracking && pip-sync
+    pip install --upgrade pip pip-tools && pip-compile --resolver=backtracking && pip-sync
     pip install -e "${PWD}[dev,lsp,doc,test]"
 }
 
@@ -38,7 +38,7 @@ if [ $# -eq 0 ]; then  # first install
     [ "$($PYTHON_BINARY --version|cut -d' ' -f2|cut -d'.' -f1)" -eq 3 ] || {
         warn "Python 3 is required"; exit 1; }
     [ "$($PYTHON_BINARY --version|cut -d' ' -f2|cut -d'.' -f2)" -gt 10 ] || {
-        warn "Python 3.11+ is required"; exit 1; }
+        warn "Python 3.12+ is required"; exit 1; }
     $PYTHON_BINARY -m venv .venv-"${PWD##*/}"
     upgrade
     2>/dev/null 1>&2 command -v pre-commit || {

--- a/tools/venv_install.sh
+++ b/tools/venv_install.sh
@@ -37,7 +37,7 @@ if [ $# -eq 0 ]; then  # first install
     fi
     [ "$($PYTHON_BINARY --version|cut -d' ' -f2|cut -d'.' -f1)" -eq 3 ] || {
         warn "Python 3 is required"; exit 1; }
-    [ "$($PYTHON_BINARY --version|cut -d' ' -f2|cut -d'.' -f2)" -gt 10 ] || {
+    [ "$($PYTHON_BINARY --version|cut -d' ' -f2|cut -d'.' -f2)" -gt 11 ] || {
         warn "Python 3.12+ is required"; exit 1; }
     $PYTHON_BINARY -m venv .venv-"${PWD##*/}"
     upgrade


### PR DESCRIPTION
It seems like the Python setup action in CI doesn't respect `[build-system]` in `pyproject.toml` :frowning_face: This ensures that the latest setuptools is being used in CI. I made the matching change to the virtual environment setup script.

Maybe this will resolve the failures to install llmvlite in  the MacOS runner.